### PR TITLE
Fix py2 stringio

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -433,9 +433,11 @@ string data in all Python versions.
 
 .. data:: StringIO
 
-   This is an fake file object for textual data.  It's an alias for
-   :class:`py2:StringIO.StringIO` in Python 2 and :class:`py3:io.StringIO` in
-   Python 3.
+   This is a fake file object for textual data.  It's an alias for
+   :class:`py3:io.StringIO` in Python 3.  In Python 2, it is a custom object
+   which inherits from :class:`py2:StringIO.StringIO` and adds context management
+   (``__enter__`` and ``__exit__`` methods), so that it behaves correctly
+   with ``with`` statements.
 
 
 .. data:: BytesIO

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -442,9 +442,9 @@ string data in all Python versions.
 
 .. data:: BytesIO
 
-   This is a fake file object for binary data.  In Python 2, it's an alias for
-   :class:`py2:StringIO.StringIO`, but in Python 3, it's an alias for
-   :class:`py3:io.BytesIO`.
+   This is a fake file object for binary data.  In Python 3, it's an alias for
+   :class:`py3:io.BytesIO`.  In Python 2, it is the same custom object as
+   ``StringIO``.
 
 
 .. decorator:: python_2_unicode_compatible

--- a/six.py
+++ b/six.py
@@ -656,16 +656,16 @@ else:
     def indexbytes(buf, i):
         return ord(buf[i])
     iterbytes = functools.partial(itertools.imap, ord)
-    import StringIO
+    import StringIO as _StringIO
 
-    class WithableStringIO(StringIO.StringIO):
+    class StringIO(_StringIO.StringIO):
         def __enter__(self):
             return self
 
         def __exit__(self, *args):
             self.close()
 
-    StringIO = BytesIO = WithableStringIO
+    StringIO = BytesIO = StringIO
     _assertCountEqual = "assertItemsEqual"
     _assertRaisesRegex = "assertRaisesRegexp"
     _assertRegex = "assertRegexpMatches"

--- a/six.py
+++ b/six.py
@@ -657,7 +657,15 @@ else:
         return ord(buf[i])
     iterbytes = functools.partial(itertools.imap, ord)
     import StringIO
-    StringIO = BytesIO = StringIO.StringIO
+
+    class WithableStringIO(StringIO.StringIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+    StringIO = BytesIO = WithableStringIO
     _assertCountEqual = "assertItemsEqual"
     _assertRaisesRegex = "assertRaisesRegexp"
     _assertRegex = "assertRegexpMatches"

--- a/test_six.py
+++ b/test_six.py
@@ -556,6 +556,10 @@ def test_StringIO():
     fp.write(six.u("hello"))
     assert fp.getvalue() == six.u("hello")
 
+    with six.StringIO() as fp2:
+        fp2.write(six.u("hello"))
+        assert fp2.getvalue() == six.u("hello")
+
 
 def test_BytesIO():
     fp = six.BytesIO()

--- a/test_six.py
+++ b/test_six.py
@@ -566,6 +566,10 @@ def test_BytesIO():
     fp.write(six.b("hello"))
     assert fp.getvalue() == six.b("hello")
 
+    with six.BytesIO() as fp2:
+        fp2.write(six.b("hello"))
+        assert fp2.getvalue() == six.b("hello")
+
 
 def test_exec_():
     def f():


### PR DESCRIPTION
With `six.StringIO` from Python 3.x, I can use the following syntax:

```
with six.StringIO() as fd:
    fd.write('Hello')
```

However, when I use Python 2.7, I have the following error:

    AttributeError: StringIO instance has no attribute '__exit__'

This commit intents to fix this difference by providing `__enter__` and `__exit__` methods to `StringIO` from Python 2.