### PR TITLE
Add function to get Exception.message

### DIFF
--- a/six.py
+++ b/six.py
@@ -710,6 +710,7 @@ else:
     finally:
         tb = None
 """)
+_add_doc(reraise, """Reraise an exception.""")
 
 
 if sys.version_info[:2] == (3, 2):
@@ -731,6 +732,15 @@ elif sys.version_info[:2] > (3, 2):
 else:
     def raise_from(value, from_value):
         raise value
+
+
+if PY3:
+    def exception_message(exception):
+        return str(exception)
+else:
+    def exception_message(exception):
+        return exception.message
+_add_doc(exception_message, "Return an Exception's message.")
 
 
 print_ = getattr(moves.builtins, "print", None)
@@ -797,8 +807,6 @@ if sys.version_info[:2] < (3, 3):
         _print(*args, **kwargs)
         if flush and fp is not None:
             fp.flush()
-
-_add_doc(reraise, """Reraise an exception.""")
 
 if sys.version_info[0:2] < (3, 4):
     def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,

--- a/test_six.py
+++ b/test_six.py
@@ -644,6 +644,13 @@ def test_raise_from():
     assert str(val) == "foo"
 
 
+def test_exception_message():
+    e = Exception("string")
+    assert six.exception_message(e) == "string"
+    e = Exception("unic\xf6de")
+    assert six.exception_message(e) == "unic\xf6de"
+
+
 def test_print_():
     save = sys.stdout
     out = sys.stdout = six.moves.StringIO()


### PR DESCRIPTION
* Add exception_message
* Move reraise _add_doc to right after definition

Manual `py.test` runs with Python2.6 and 3.5 passed, but `tox` failed with `AttributeError: 'module' object has no attribute 'exception_message'`.