### PR TITLE
Adds dbm move

### DIFF
--- a/six.py
+++ b/six.py
@@ -256,6 +256,7 @@ _moved_attributes = [
     MovedModule("configparser", "ConfigParser"),
     MovedModule("copyreg", "copy_reg"),
     MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("dbm", "anydbm"),
     MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
     MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
     MovedModule("http_cookies", "Cookie", "http.cookies"),


### PR DESCRIPTION
The module "anydbm" has been moved to "dbm" in Python 3.

Defines the "dbm" move from "anydbm".

[1] https://docs.python.org/2/library/anydbm.html