### PR TITLE
Avoid dependency cycle by using distutils when setuptools isn't available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@
 
 from __future__ import with_statement
 
-from setuptools import setup
+# Six is a dependency of setuptools, so using setuptools creates a
+# circular dependency when building a Python stack from source. We
+# therefore prefer distutils to setuptools for installing six.
+from distutils.core import setup
 
 import six
 

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,11 @@ from __future__ import with_statement
 
 # Six is a dependency of setuptools, so using setuptools creates a
 # circular dependency when building a Python stack from source. We
-# therefore prefer distutils to setuptools for installing six.
-from distutils.core import setup
+# therefore allow falling back to distutils to install six.
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 import six
 


### PR DESCRIPTION
Fixes #183.

- See discussion in pypa/setuptools#980
- `six` is a dependency of `setuptools`, so depending on `setuptools` creates a circular dependency.

@dstufft @jaraco @benjaminp @adamjstewart