### PR TITLE
Fix more issues with setuptools externally depending on six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 from __future__ import with_statement
+import ast
 
 # Six is a dependency of setuptools, so using setuptools creates a
 # circular dependency when building a Python stack from source. We
@@ -27,8 +28,6 @@ try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-
-import six
 
 six_classifiers = [
     "Programming Language :: Python :: 2",
@@ -42,8 +41,15 @@ six_classifiers = [
 with open("README", "r") as fp:
     six_long_description = fp.read()
 
+# Do not import `six` yet, lest we import some random version on sys.path.
+with open("six.py", "r") as fp:
+    for line in fp:
+        if line.startswith("__version__"):
+            version = ast.literal_eval(line.split("=", 1)[1].strip())
+            break
+
 setup(name="six",
-      version=six.__version__,
+      version=version,
       author="Benjamin Peterson",
       author_email="benjamin@python.org",
       url="http://pypi.python.org/pypi/six/",

--- a/six.py
+++ b/six.py
@@ -223,6 +223,7 @@ class _SixMetaPathImporter(object):
         return None
     get_source = get_code  # same as get_code
 
+
 _importer = _SixMetaPathImporter(__name__)
 
 
@@ -483,6 +484,7 @@ class Module_six_moves_urllib(types.ModuleType):
 
     def __dir__(self):
         return ['parse', 'error', 'request', 'response', 'robotparser']
+
 
 _importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
                       "moves.urllib")

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ indexserver=
 
 [testenv]
 deps= pytest
+setenv=
+    PYTHONPATH=.
 commands= py.test -rfsxX {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
 - In tox. make sure we're running our tests with the checked out six, not some six installed in the virtualenv (#182).

- In `setup.py`, don't import six to get the version number (#188).

Also, fix some flake8 complains in tox.