### PR TITLE
Temporary metaclass should not inherit from "meta"

### DIFF
--- a/six.py
+++ b/six.py
@@ -820,7 +820,7 @@ def with_metaclass(meta, *bases):
     # This requires a bit of explanation: the basic idea is to make a dummy
     # metaclass for one level of class instantiation that replaces itself with
     # the actual metaclass.
-    class metaclass(meta):
+    class metaclass(type):
 
         def __new__(cls, name, this_bases, d):
             return meta(name, bases, d)


### PR DESCRIPTION
In the current implementation of `with_metaclass`, the temporary `metaclass` inherits from `meta`. Later we call `type.__new__(metaclass, ...)`. This can lead to errors of the form
```
type.__new__(metaclass) is not safe, use ....__new__()
```
if `meta` is an extension type instead of a plain Python class.

Since I see no reason for inheriting from `meta`, this patch fixes that to inherit from the base class `type` instead.