### PR TITLE
Fix pickling of _LazyModule

### DIFF
--- a/six.py
+++ b/six.py
@@ -135,6 +135,9 @@ class _LazyModule(types.ModuleType):
     # Subclasses should override this
     _moved_attributes = []
 
+    def __reduce__(self):
+        return _import_module, (self.__name__,)
+
 
 class MovedAttribute(_LazyDescr):
 


### PR DESCRIPTION
Since importing six automatically sets up six.moves, _LazyModule
instances can be unpickled by just importing them.

Fixes #194.