### PR TITLE
Correct from "an" to "a".

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -433,7 +433,7 @@ string data in all Python versions.
 
 .. data:: StringIO
 
-   This is an fake file object for textual data.  It's an alias for
+   This is a fake file object for textual data.  It's an alias for
    :class:`py2:StringIO.StringIO` in Python 2 and :class:`py3:io.StringIO` in
    Python 3.
 


### PR DESCRIPTION
This corrects a small grammar problem I noticed. Please consider merging. Thanks for six!