### PR TITLE
Rename [wheel] section to [bdist_wheel] as the former is legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [flake8]
@@ -15,4 +15,3 @@ flakes-ignore =
     documentation/*.py ALL
     test_six.py ALL
     six.py UndefinedName
-


### PR DESCRIPTION
See:

https://bitbucket.org/pypa/wheel/src/54ddbcc9cec25e1f4d111a142b8bfaa163130a61/wheel/bdist_wheel.py?fileviewer=file-view-default#bdist_wheel.py-119:125

http://pythonwheels.com/