### PR TITLE
Add urlparse.scheme_chars to list of moves

### DIFF
--- a/six.py
+++ b/six.py
@@ -330,6 +330,7 @@ _urllib_parse_moved_attributes = [
     MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
     MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
     MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("scheme_chars", "urlparse", "urllib.parse"),
     MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
     MovedAttribute("urljoin", "urlparse", "urllib.parse"),
     MovedAttribute("urlparse", "urlparse", "urllib.parse"),


### PR DESCRIPTION
This is the only non-private name in python 2's `urlparse` which is not present in `six.moves.urllib.parse`. It is used in a large number of projects, so would be a good candidate for inclusion in six: https://github.com/search?utf8=%E2%9C%93&q=%22scheme_chars%22+extension%3Apy&type=Code&ref=advsearch&l=&l=