### PR TITLE
Add parse_http_list and parse_keqv_list to moved urllib.request

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ This file lists the changes in each six version.
 Development version
 -------------------
 
-- Pull request #NNN: Add parse_http_list and parse_keqv_list to moved
+- Pull request #203: Add parse_http_list and parse_keqv_list to moved
   urllib.request.
 
 - Pull request #172 and issue #171: Add unquote_to_bytes to moved urllib.parse.

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ This file lists the changes in each six version.
 Development version
 -------------------
 
+- Pull request #NNN: Add parse_http_list and parse_keqv_list to moved
+  urllib.request.
+
 - Pull request #172 and issue #171: Add unquote_to_bytes to moved urllib.parse.
 
 - Pull request #167: Add `six.moves.getstatusoutput` and `six.moves.getoutput`.

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -771,6 +771,8 @@ and :mod:`py2:urllib2`:
 * :func:`py2:urllib2.urlopen`
 * :func:`py2:urllib2.install_opener`
 * :func:`py2:urllib2.build_opener`
+* :func:`py2:urllib2.parse_http_list`
+* :func:`py2:urllib2.parse_keqv_list`
 * :class:`py2:urllib2.Request`
 * :class:`py2:urllib2.OpenerDirector`
 * :class:`py2:urllib2.HTTPDefaultErrorHandler`

--- a/six.py
+++ b/six.py
@@ -421,6 +421,8 @@ _urllib_request_moved_attributes = [
     MovedAttribute("URLopener", "urllib", "urllib.request"),
     MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
     MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
 ]
 for attr in _urllib_request_moved_attributes:
     setattr(Module_six_moves_urllib_request, attr.name, attr)


### PR DESCRIPTION
[CherryPy relies on these public though undocumented functions](https://github.com/cherrypy/cherrypy/blob/v11.0.0/cherrypy/_cpcompat.py#L139).