### PR TITLE
add ensure_binary/str/text helper functions

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -433,6 +433,24 @@ string data in all Python versions.
    a bytes object iterator in Python 3.
 
 
+.. function:: ensure_binary(s, encoding='utf-8', errors='strict')
+
+  A helper function to ensure output is :data:`binary_type`. ``encoding``, ``errors``
+  are the same as https://docs.python.org/3/library/stdtypes.html#str.encode
+
+
+.. function:: ensure_str(s, encoding='utf-8', errors='strict')
+
+  A helper function to ensure output is ``str``. ``encoding``, ``errors``
+  are the same as https://docs.python.org/3/library/stdtypes.html#str.encode
+
+
+.. function:: ensure_text(s, encoding='utf-8', errors='strict')
+
+  A helper function to ensure output is :data:`text_type`. ``encoding``, ``errors``
+  are the same as https://docs.python.org/3/library/stdtypes.html#str.encode
+
+
 .. data:: StringIO
 
    This is a fake file object for textual data.  It's an alias for

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -436,19 +436,19 @@ string data in all Python versions.
 .. function:: ensure_binary(s, encoding='utf-8', errors='strict')
 
   A helper function to ensure output is :data:`binary_type`. ``encoding``, ``errors``
-  are the same as https://docs.python.org/3/library/stdtypes.html#str.encode
+  are the same as :meth:`py3:str.encode`
 
 
 .. function:: ensure_str(s, encoding='utf-8', errors='strict')
 
   A helper function to ensure output is ``str``. ``encoding``, ``errors``
-  are the same as https://docs.python.org/3/library/stdtypes.html#str.encode
+  are the same :meth:`py3:str.encode`
 
 
 .. function:: ensure_text(s, encoding='utf-8', errors='strict')
 
   A helper function to ensure output is :data:`text_type`. ``encoding``, ``errors``
-  are the same as https://docs.python.org/3/library/stdtypes.html#str.encode
+  are the same as :meth:`py3:str.encode`
 
 
 .. data:: StringIO

--- a/six.py
+++ b/six.py
@@ -854,16 +854,17 @@ def ensure_binary(s, encoding='utf-8', errors='strict'):
       - `str` -> encoded to `bytes`
       - `bytes` -> `bytes`
     """
-    if not isinstance(s, (text_type, binary_type)):
-        raise TypeError("not expecting type '%s'" % type(s))
     if isinstance(s, text_type):
         return s.encode(encoding, errors)
-    else:
+    elif isinstance(s, binary_type):
         return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
 
 
 def ensure_str(s, encoding='utf-8', errors='strict'):
-    """ A helper function to ensure output is six.str_type.
+    """ A helper function to ensure output is `str`.
+
     For Python 2:
       - `unicode` -> encoded to `str`
       - `str` -> `str`
@@ -892,12 +893,13 @@ def ensure_text(s, encoding='utf-8', errors='strict'):
       - `str` -> `str`
       - `bytes` -> decoded to `str`
     """
-    if not isinstance(s, (text_type, binary_type)):
-        raise TypeError("not expecting type '%s'" % type(s))
     if isinstance(s, binary_type):
         return s.decode(encoding, errors)
-    else:
+    elif isinstance(s, text_type):
         return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
 
 
 def python_2_unicode_compatible(klass):

--- a/six.py
+++ b/six.py
@@ -843,6 +843,63 @@ def add_metaclass(metaclass):
     return wrapper
 
 
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    """ A helper function to ensure output is six.binary_type.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    else:
+        return s
+
+
+def ensure_str(s, encoding='utf-8', errors='strict'):
+    """ A helper function to ensure output is six.str_type.
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if PY2 and isinstance(s, text_type):
+        s = s.encode(encoding, errors)
+    elif PY3 and isinstance(s, binary_type):
+        s = s.decode(encoding, errors)
+    return s
+
+
+def ensure_text(s, encoding='utf-8', errors='strict'):
+    """ A helper function to ensure output is six.text_type.
+
+    For Python 2:
+      - `unicode` -> `unicode`
+      - `str` -> `unicode`
+
+    For Python 3:
+      - `str` -> `str`
+      - `bytes` -> decoded to `str`
+    """
+    if not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
+    if isinstance(s, binary_type):
+        return s.decode(encoding, errors)
+    else:
+        return s
+
+
 def python_2_unicode_compatible(klass):
     """
     A decorator that defines __unicode__ and __str__ methods under Python 2.

--- a/test_six.py
+++ b/test_six.py
@@ -905,51 +905,54 @@ def test_python_2_unicode_compatible():
     assert getattr(six.moves.builtins, 'bytes', str)(my_test) == six.b("hello")
 
 
-def test_ensure_binary_raise_type_error():
-    with py.test.raises(TypeError):
-        six.ensure_str(8)
+class EnsureTests(unittest.TestCase):
 
+    # grinning face emoji
+    UNICODE_EMOJI = six.u("\U0001F600")
+    BINARY_EMOJI = b"\xf0\x9f\x98\x80"
 
-def test_ensure_binary_raise():
-    unicode_grinning_face = six.u("\U0001F600")
-    binary_grinning_face = b"\xf0\x9f\x98\x80"
-    if six.PY2:
-        # PY2: unicode -> str
-        assert six.ensure_binary(unicode_grinning_face) == binary_grinning_face
-        # PY2: str -> str
-        assert six.ensure_binary(binary_grinning_face) == binary_grinning_face
-    else:
-        # PY3: str -> bytes
-        assert six.ensure_binary(unicode_grinning_face) == binary_grinning_face
-        # PY3: bytes -> bytes
-        assert six.ensure_binary(binary_grinning_face) == binary_grinning_face
+    def test_ensure_binary_raise_type_error(self):
+        with py.test.raises(TypeError):
+            six.ensure_str(8)
 
+    def test_ensure_binary_raise(self):
+        converted_unicode = six.ensure_binary(self.UNICODE_EMOJI, encoding='utf-8', errors='strict')
+        converted_binary = six.ensure_binary(self.BINARY_EMOJI, encoding="utf-8", errors='strict')
+        if six.PY2:
+            # PY2: unicode -> str
+            assert converted_unicode == self.BINARY_EMOJI and isinstance(converted_unicode, str)
+            # PY2: str -> str
+            assert converted_binary == self.BINARY_EMOJI and isinstance(converted_binary, str)
+        else:
+            # PY3: str -> bytes
+            assert converted_unicode == self.BINARY_EMOJI and isinstance(converted_unicode, bytes)
+            # PY3: bytes -> bytes
+            assert converted_binary == self.BINARY_EMOJI and isinstance(converted_binary, bytes)
 
-def test_ensure_str():
-    unicode_grinning_face = six.u("\U0001F600")
-    binary_grinning_face = b"\xf0\x9f\x98\x80"
-    if six.PY2:
-        # PY2: unicode -> str
-        assert six.ensure_str(unicode_grinning_face) == binary_grinning_face
-        # PY2: str -> str
-        assert six.ensure_str(binary_grinning_face) == binary_grinning_face
-    else:
-        # PY3: str -> str
-        assert six.ensure_str(unicode_grinning_face) == unicode_grinning_face
-        # PY3: bytes -> str
-        assert six.ensure_str(binary_grinning_face) == unicode_grinning_face
+    def test_ensure_str(self):
+        converted_unicode = six.ensure_str(self.UNICODE_EMOJI, encoding='utf-8', errors='strict')
+        converted_binary = six.ensure_str(self.BINARY_EMOJI, encoding="utf-8", errors='strict')
+        if six.PY2:
+            # PY2: unicode -> str
+            assert converted_unicode == self.BINARY_EMOJI and isinstance(converted_unicode, str)
+            # PY2: str -> str
+            assert converted_binary == self.BINARY_EMOJI and isinstance(converted_binary, str)
+        else:
+            # PY3: str -> str
+            assert converted_unicode == self.UNICODE_EMOJI and isinstance(converted_unicode, str)
+            # PY3: bytes -> str
+            assert converted_binary == self.UNICODE_EMOJI and isinstance(converted_unicode, str)
 
-
-def test_ensure_text():
-    unicode_grinning_face = six.u("\U0001F600")
-    binary_grinning_face = b"\xf0\x9f\x98\x80"
-    if six.PY2:
-        # PY2: unicode -> unicode
-        assert six.ensure_text(unicode_grinning_face) == unicode_grinning_face
-        # PY2: str -> unicode
-        assert six.ensure_text(binary_grinning_face) == unicode_grinning_face
-    else:
-        # PY3: str -> str
-        assert six.ensure_text(unicode_grinning_face) == unicode_grinning_face
-        # PY3: bytes -> str
-        assert six.ensure_text(binary_grinning_face) == unicode_grinning_face
+    def test_ensure_text(self):
+        converted_unicode = six.ensure_text(self.UNICODE_EMOJI, encoding='utf-8', errors='strict')
+        converted_binary = six.ensure_text(self.BINARY_EMOJI, encoding="utf-8", errors='strict')
+        if six.PY2:
+            # PY2: unicode -> unicode
+            assert converted_unicode == self.UNICODE_EMOJI and isinstance(converted_unicode, unicode)
+            # PY2: str -> unicode
+            assert converted_binary == self.UNICODE_EMOJI and isinstance(converted_unicode, unicode)
+        else:
+            # PY3: str -> str
+            assert converted_unicode == self.UNICODE_EMOJI and isinstance(converted_unicode, str)
+            # PY3: bytes -> str
+            assert converted_binary == self.UNICODE_EMOJI and isinstance(converted_unicode, str)

--- a/test_six.py
+++ b/test_six.py
@@ -905,7 +905,7 @@ def test_python_2_unicode_compatible():
     assert getattr(six.moves.builtins, 'bytes', str)(my_test) == six.b("hello")
 
 
-class EnsureTests(unittest.TestCase):
+class EnsureTests:
 
     # grinning face emoji
     UNICODE_EMOJI = six.u("\U0001F600")
@@ -914,6 +914,11 @@ class EnsureTests(unittest.TestCase):
     def test_ensure_binary_raise_type_error(self):
         with py.test.raises(TypeError):
             six.ensure_str(8)
+
+    def test_errors_and_encoding(self):
+        six.ensure_binary(self.UNICODE_EMOJI, encoding='latin-1', errors='ignore')
+        with py.test.raises(UnicodeEncodeError):
+            six.ensure_binary(self.UNICODE_EMOJI, encoding='latin-1', errors='strict')
 
     def test_ensure_binary_raise(self):
         converted_unicode = six.ensure_binary(self.UNICODE_EMOJI, encoding='utf-8', errors='strict')

--- a/test_six.py
+++ b/test_six.py
@@ -903,3 +903,53 @@ def test_python_2_unicode_compatible():
         assert str(my_test) == six.u("hello")
 
     assert getattr(six.moves.builtins, 'bytes', str)(my_test) == six.b("hello")
+
+
+def test_ensure_binary_raise_type_error():
+    with py.test.raises(TypeError):
+        six.ensure_str(8)
+
+
+def test_ensure_binary_raise():
+    unicode_grinning_face = six.u("\U0001F600")
+    binary_grinning_face = b"\xf0\x9f\x98\x80"
+    if six.PY2:
+        # PY2: unicode -> str
+        assert six.ensure_binary(unicode_grinning_face) == binary_grinning_face
+        # PY2: str -> str
+        assert six.ensure_binary(binary_grinning_face) == binary_grinning_face
+    else:
+        # PY3: str -> bytes
+        assert six.ensure_binary(unicode_grinning_face) == binary_grinning_face
+        # PY3: bytes -> bytes
+        assert six.ensure_binary(binary_grinning_face) == binary_grinning_face
+
+
+def test_ensure_str():
+    unicode_grinning_face = six.u("\U0001F600")
+    binary_grinning_face = b"\xf0\x9f\x98\x80"
+    if six.PY2:
+        # PY2: unicode -> str
+        assert six.ensure_str(unicode_grinning_face) == binary_grinning_face
+        # PY2: str -> str
+        assert six.ensure_str(binary_grinning_face) == binary_grinning_face
+    else:
+        # PY3: str -> str
+        assert six.ensure_str(unicode_grinning_face) == unicode_grinning_face
+        # PY3: bytes -> str
+        assert six.ensure_str(binary_grinning_face) == unicode_grinning_face
+
+
+def test_ensure_text():
+    unicode_grinning_face = six.u("\U0001F600")
+    binary_grinning_face = b"\xf0\x9f\x98\x80"
+    if six.PY2:
+        # PY2: unicode -> unicode
+        assert six.ensure_text(unicode_grinning_face) == unicode_grinning_face
+        # PY2: str -> unicode
+        assert six.ensure_text(binary_grinning_face) == unicode_grinning_face
+    else:
+        # PY3: str -> str
+        assert six.ensure_text(unicode_grinning_face) == unicode_grinning_face
+        # PY3: bytes -> str
+        assert six.ensure_text(binary_grinning_face) == unicode_grinning_face


### PR DESCRIPTION
* Summary
add ensure_binary, ensure_str, ensure_text helper functions to solve the encoding compatibility
between py2 and py3 more easily.
-- ensure_binary, input --> six.binary_type
-- ensure_str, input -> six.string_type
-- ensure_text, input -> six.text_type
This is mentioned in Lisa Guo's keynote in Pycon 2017 (from 31:21 in https://www.youtube.com/watch?v=66XoCk79kjM), which helped Instagram to upgrade to Python 3 and I hope this can help other developers, too

* Test Plan
add new unit tests to cover added code
```
 195 passed, 2 skipped in 0.48 seconds 
```