### PR TITLE
Fix typo

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -104,7 +104,7 @@ Here's example usage of the module::
 Object model compatibility
 >>>>>>>>>>>>>>>>>>>>>>>>>>
 
-Python 3 renamed the attributes of several intepreter data structures.  The
+Python 3 renamed the attributes of several interpreter data structures.  The
 following accessors are available.  Note that the recommended way to inspect
 functions and methods is the stdlib :mod:`py3:inspect` module.
 


### PR DESCRIPTION
I initially noticed a typo here:

> [This is so the **_appropiate_** modules can be found when running on Python 2.](https://pythonhosted.org/six/#module-six.moves)

But it was already fixed when I forked the repo. So, it seems like the docs on `pythonhosted.org` are not up to date?

Anyways, I found one more typo (this time in both `index.rst` and `pythonhosted.org`):

> [Python 3 renamed the attributes of several **_intepreter_** data structures.](https://pythonhosted.org/six/#object-model-compatibility)
