### PR TITLE
Add ``python_2_bool_compatible``

### DIFF
--- a/six.py
+++ b/six.py
@@ -861,6 +861,24 @@ def python_2_unicode_compatible(klass):
     return klass
 
 
+def python_2_bool_compatible(klass):
+    """
+    A decorator that defines __nonzero__ method under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __bool__ method
+    returning bool value and apply this decorator to the class.
+    """
+    if PY2:
+        if '__bool__' not in klass.__dict__:
+            raise ValueError("@python_2_bool_compatible cannot be applied "
+                             "to %s because it doesn't define __bool__()." %
+                             klass.__name__)
+        klass.__nonzero__ = klass.__bool__
+        del klass.__bool__
+    return klass
+
+
 # Complete the moves implementation.
 # This code is at the end of this module to speed up module loading.
 # Turn this module into a package.

--- a/test_six.py
+++ b/test_six.py
@@ -903,3 +903,14 @@ def test_python_2_unicode_compatible():
         assert str(my_test) == six.u("hello")
 
     assert getattr(six.moves.builtins, 'bytes', str)(my_test) == six.b("hello")
+
+
+def test_python_2_bool_compatible():
+    @six.python_2_bool_compatible
+    class MyTest(object):
+        def __bool__(self):
+            return False
+
+    my_test = MyTest()
+
+    assert bool(my_test) is False


### PR DESCRIPTION
Python 2 calls ``obj.__nonzero__`` when convert ``obj`` to bool,
Python 3 calls ``obj.__bool__``    when convert ``obj`` to bool.

Add ``python_2_bool_compatible``, which is a decorator that
defines ``__nonzero__`` method under Python 2.
Under Python 3 it does nothing.

Example

```python
>>> @six.python_2_bool_compatible
... class Klass(object):
...     def __bool__(self):
...         return False
>>> obj = Klass()
>>> bool(obj)
False
```