### PR TITLE
Update six.py: support _func_name of a function

### DIFF
--- a/six.py
+++ b/six.py
@@ -511,6 +511,7 @@ if PY3:
 
     _func_closure = "__closure__"
     _func_code = "__code__"
+    _func_name = "__name__"
     _func_defaults = "__defaults__"
     _func_globals = "__globals__"
 else:
@@ -519,6 +520,7 @@ else:
 
     _func_closure = "func_closure"
     _func_code = "func_code"
+    _func_name = "func_name"
     _func_defaults = "func_defaults"
     _func_globals = "func_globals"
 


### PR DESCRIPTION
Add _func_name for name of a function. 

currenly py3 uses `__name__` and py2 uses `func_name`