### PR TITLE
Ignore the build directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+build
 dist
 MANIFEST
 documentation/_build


### PR DESCRIPTION
Generated by setup.py when building packages.