### PR TITLE
Fix py.test command

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ indexserver=
 
 [testenv]
 deps= pytest
-commands= py.test -rfsxX {posargs}
+commands= python -m pytest -rfsxX {posargs}
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Linux distributions provides py.test script on their own way for
support python2 and python3 both together.
For example py.test with python2 shebang or py.test with python3
one. Or scripts with another names, e.g. py.test - python2 shebang,
py.test3 - python3 shebang. Therefore it is better to import module
instead.