### PR TITLE
Add hasattr function

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -473,6 +473,19 @@ string data in all Python versions.
    that returns the result of ``__unicode__()`` encoded with UTF-8.
 
 
+Behavior changes
+>>>>>>>>>>>>>>>>
+
+Six also provides shims for changes in behavior.
+
+.. function:: hasattr(obj, name)
+
+    In Python 2, hasattr() catches all exceptions, while on Python 3 it only
+    catches `~py3:AttributeError`. On Python 3, this function is an alias to
+    `~py3:hasattr`. On Python 2, it implements the (more sensible) Python 3
+    behaviour
+
+
 unittest assertions
 >>>>>>>>>>>>>>>>>>>
 

--- a/six.py
+++ b/six.py
@@ -925,6 +925,20 @@ def python_2_unicode_compatible(klass):
     return klass
 
 
+if PY2:
+    def hasattr(obj, name):
+        """Return whether the object has an attribute with the given name.
+
+        This is done by calling getattr(obj, name) and catching AttributeError."""
+        try:
+            getattr(obj, name)
+            return True
+        except AttributeError:
+            return False
+else:
+    hasattr = hasattr
+
+
 # Complete the moves implementation.
 # This code is at the end of this module to speed up module loading.
 # Turn this module into a package.

--- a/test_six.py
+++ b/test_six.py
@@ -934,6 +934,28 @@ def test_python_2_unicode_compatible():
     assert getattr(six.moves.builtins, 'bytes', str)(my_test) == six.b("hello")
 
 
+def test_hasattr():
+    class MyTest():
+        @property
+        def no_error(self):
+            pass
+
+        @property
+        def div_error(self):
+            raise ZeroDivisionError
+
+        @property
+        def attribute_error(self):
+            raise AttributeError
+
+    my_test = MyTest()
+    assert six.hasattr(my_test, "no_error")
+    assert not six.hasattr(my_test, "doesnotexist")
+    assert not six.hasattr(my_test, "attribute_error")
+    with py.test.raises(ZeroDivisionError):
+        six.hasattr(my_test, "div_error")
+
+
 class EnsureTests:
 
     # grinning face emoji


### PR DESCRIPTION
The hasattr() function on python2 is famously dangerous and a frequent
source of problems. This backports the slighly less dangerous Python 3 version
to Python2.