### PR TITLE
fix translation of subprocess.getoutput to be aligned with Py version

### DIFF
--- a/six.py
+++ b/six.py
@@ -241,7 +241,6 @@ _moved_attributes = [
     MovedAttribute("map", "itertools", "builtins", "imap", "map"),
     MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
     MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
-    MovedAttribute("getoutput", "commands", "subprocess"),
     MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
     MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
     MovedAttribute("reduce", "__builtin__", "functools"),
@@ -301,6 +300,9 @@ _moved_attributes = [
     MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
     MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
 ]
+if not (sys.platform == "win32" and sys.version_info[:3] < (3, 3, 4)):
+    #support for subprocess.getoutput() on Windows was added for Py>=3.3.4
+    _moved_attributes.append(MovedAttribute("getoutput", "commands", "subprocess"))
 # Add windows specific modules.
 if sys.platform == "win32":
     _moved_attributes += [

--- a/test_six.py
+++ b/test_six.py
@@ -231,11 +231,12 @@ def test_map():
     from six.moves import map
     assert six.advance_iterator(map(lambda x: x + 1, range(2))) == 1
 
-
+@py.test.mark.skipif("sys.version_info[:3] < (3, 3, 4) and sys.platform.startswith('win')")
 def test_getoutput():
     from six.moves import getoutput
     output = getoutput('echo "foo"')
-    assert output == 'foo'
+    #On Unix platforms, foo is returned and on Windows, "foo".
+    assert output in ['foo', '"foo"']
 
 
 def test_zip():


### PR DESCRIPTION
Also fix the corresponding test.

@benjaminp 