### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. image:: http://img.shields.io/pypi/v/six.svg
-   :target: https://pypi.python.org/pypi/six
+   :target: https://pypi.org/project/six/
 
 .. image:: https://travis-ci.org/benjaminp/six.svg?branch=master
     :target: https://travis-ci.org/benjaminp/six

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -13,7 +13,7 @@ Python 3.  It is intended to support codebases that work on both Python 2 and 3
 without modification.  six consists of only one Python file, so it is painless
 to copy into a project.
 
-Six can be downloaded on `PyPI <https://pypi.python.org/pypi/six/>`_.  Its bug
+Six can be downloaded on `PyPI <https://pypi.org/project/six/>`_.  Its bug
 tracker and code hosting is on `GitHub <https://github.com/benjaminp/six>`_.
 
 The name, "six", comes from the fact that 2*3 equals 6.  Why not addition?

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=py26,py27,py31,py32,py33,py34,pypy,flake8
 indexserver=
-    default = https://pypi.python.org/simple
+    default = https://pypi.org/simple
     testrun = http://pypi.testrun.org
 
 [testenv]


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html