### PR TITLE
eventlet/eventlet#480: use importlib.import_module, not __import__()

### DIFF
--- a/six.py
+++ b/six.py
@@ -23,6 +23,7 @@
 from __future__ import absolute_import
 
 import functools
+import importlib
 import itertools
 import operator
 import sys
@@ -77,12 +78,6 @@ def _add_doc(func, doc):
     func.__doc__ = doc
 
 
-def _import_module(name):
-    """Import module, returning the module after the last dot."""
-    __import__(name)
-    return sys.modules[name]
-
-
 class _LazyDescr(object):
 
     def __init__(self, name):
@@ -112,7 +107,7 @@ class MovedModule(_LazyDescr):
             self.mod = old
 
     def _resolve(self):
-        return _import_module(self.mod)
+        return importlib.import_module(self.mod)
 
     def __getattr__(self, attr):
         _module = self._resolve()
@@ -157,7 +152,7 @@ class MovedAttribute(_LazyDescr):
             self.attr = old_attr
 
     def _resolve(self):
-        module = _import_module(self.mod)
+        module = importlib.import_module(self.mod)
         return getattr(module, self.attr)
 
 

--- a/six.py
+++ b/six.py
@@ -23,7 +23,6 @@
 from __future__ import absolute_import
 
 import functools
-import importlib
 import itertools
 import operator
 import sys
@@ -78,6 +77,16 @@ def _add_doc(func, doc):
     func.__doc__ = doc
 
 
+try:
+    from importlib import import_module as _import_module
+except ImportError:
+    # Python 2.6 doesn't yet support importlib
+    def _import_module(name):
+        """Import module, returning the module after the last dot."""
+        __import__(name)
+        return sys.modules[name]
+
+
 class _LazyDescr(object):
 
     def __init__(self, name):
@@ -107,7 +116,7 @@ class MovedModule(_LazyDescr):
             self.mod = old
 
     def _resolve(self):
-        return importlib.import_module(self.mod)
+        return _import_module(self.mod)
 
     def __getattr__(self, attr):
         _module = self._resolve()
@@ -152,7 +161,7 @@ class MovedAttribute(_LazyDescr):
             self.attr = old_attr
 
     def _resolve(self):
-        module = importlib.import_module(self.mod)
+        module = _import_module(self.mod)
         return getattr(module, self.attr)
 
 


### PR DESCRIPTION
Libraries using `six.MovedModule` or `six.MovedAttribute` presently do not honor [PEP 302](https://www.python.org/dev/peps/pep-0302/) import hooks because `__import__()` doesn't support them. (See https://github.com/eventlet/eventlet/issues/480)

Using `importlib.import_module()` allows removing the `six._import_module()` function, whose purpose is to map `__import__()` functionality to what `importlib.import_module()` already provides.