### PR TITLE
Provide functions that allow the dictionary to be used more efficiently.

### DIFF
--- a/six.py
+++ b/six.py
@@ -594,6 +594,16 @@ if PY3:
     viewvalues = operator.methodcaller("values")
 
     viewitems = operator.methodcaller("items")
+
+    def listkeys(d, **kw):
+        return list(d.keys(**kw))
+
+    def listitems(d, **kw):
+        return list(d.items(**kw))
+
+    def listvalues(d, **kw):
+        return list(d.values(**kw))
+
 else:
     def iterkeys(d, **kw):
         return d.iterkeys(**kw)
@@ -613,13 +623,25 @@ else:
 
     viewitems = operator.methodcaller("viewitems")
 
+    def listkeys(d, **kw):
+        return d.keys(**kw)
+
+    def listitems(d, **kw):
+        return d.items(**kw)
+
+    def listvalues(d, **kw):
+        return d.values(**kw)
+
 _add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
 _add_doc(itervalues, "Return an iterator over the values of a dictionary.")
 _add_doc(iteritems,
          "Return an iterator over the (key, value) pairs of a dictionary.")
 _add_doc(iterlists,
          "Return an iterator over the (key, [values]) pairs of a dictionary.")
-
+_add_doc(listkeys, "Return a list over the keys of a dictionary.")
+_add_doc(listvalues, "Return a list over the values of a dictionary.")
+_add_doc(listitems,
+         "Return a list over the (key, value) pairs of a dictionary.")
 
 if PY3:
     def b(s):

--- a/test_six.py
+++ b/test_six.py
@@ -416,6 +416,28 @@ def test_dictionary_iterators(monkeypatch):
         monkeypatch.undo()
 
 
+def test_dictionary_lists(monkeypatch):
+
+    class MyDict(dict):
+        pass
+
+    d = MyDict(zip(range(10), reversed(range(10))))
+    for name in "keys", "values", "items":
+        meth = getattr(six, "list" + name)
+        res = meth(d)
+        assert isinstance(res, list)
+        record = []
+
+        def with_kw(*args, **kw):
+            record.append(kw["kw"])
+            return old(*args)
+        old = getattr(MyDict, name)
+        monkeypatch.setattr(MyDict, name, with_kw)
+        meth(d, kw=42)
+        assert record == [42]
+        monkeypatch.undo()
+
+
 @py.test.mark.skipif("sys.version_info[:2] < (2, 7)",
                 reason="view methods on dictionaries only available on 2.7+")
 def test_dictionary_views():


### PR DESCRIPTION
## Problem
Sometimes it is not possible to provide code in python 2 and python 3 without any performance losses.
The dictionary functions `.keys()`, `items()`, `values()` used to return a `list`, but now they return a `view`.

E.g.:
``` 
list(d.keys())
list(d.items())
list(d.values()) 
```

This would work in python 2 and python 3 but it is not efficient.
In python 2 it copies the memory into a new list instead of using the existing list.

## Solution
Defining a function which provides a list in python 2 and python 3 without performance losses.
E.g.:
```
d.keys() -> six.listkeys(d)
d.items() -> six.listitems(d)
d.values() -> six.listvalues(d)
``` 
