### PR TITLE
Add update_wrapper and fix wraps handing of missing attrs

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -257,11 +257,10 @@ functions and methods is the stdlib :mod:`py3:inspect` module.
 
 .. decorator:: wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS, updated=functools.WRAPPER_UPDATES)
 
-   This does exactly the same what the :func:`py3:functools.wraps` decorator
-   does on Python versions after 3.2 by using :func:`update_wrapper`
-   internally. It sets the ``__wrapped__`` attribute on what it decorates and
-   it doesn't raise an error if any of the attributes mentioned in ``assigned``
-   and ``updated`` are missing on ``wrapped`` object.
+   This is Python 3.2's :func:`py3:functools.wraps` decorator.  It sets the
+   ``__wrapped__`` attribute on what it decorates.  It doesn't raise an error if
+   any of the attributes mentioned in ``assigned`` and ``updated`` are missing
+   on ``wrapped`` object.
 
 
 Syntax compatibility

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -255,15 +255,6 @@ functions and methods is the stdlib :mod:`py3:inspect` module.
    aliased to :class:`py3:object`.)
 
 
-.. function:: update_wrapper(wrapper, wrapped, assigned=functools.WRAPPER_ASSIGNMENTS, updated=functools.WRAPPER_UPDATES)
-
-   This does exactly the same what the :func:`py3:functools.update_wrapper`
-   function does on Python versions after 3.2. It sets the ``__wrapped__``
-   attribute on ``wrapper`` object and it doesn't raise an error if any of the
-   attributes mentioned in ``assigned`` and ``updated`` are missing on
-   ``wrapped`` object.
-
-
 .. decorator:: wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS, updated=functools.WRAPPER_UPDATES)
 
    This does exactly the same what the :func:`py3:functools.wraps` decorator

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -255,11 +255,22 @@ functions and methods is the stdlib :mod:`py3:inspect` module.
    aliased to :class:`py3:object`.)
 
 
+.. function:: update_wrapper(wrapper, wrapped, assigned=functools.WRAPPER_ASSIGNMENTS, updated=functools.WRAPPER_UPDATES)
+
+   This does exactly the same what the :func:`py3:functools.update_wrapper`
+   function does on Python versions after 3.2. It sets the ``__wrapped__``
+   attribute on ``wrapper`` object and it doesn't raise an error if any of the
+   attributes mentioned in ``assigned`` and ``updated`` are missing on
+   ``wrapped`` object.
+
+
 .. decorator:: wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS, updated=functools.WRAPPER_UPDATES)
 
-   This is exactly the :func:`py3:functools.wraps` decorator, but it sets the
-   ``__wrapped__`` attribute on what it decorates as :func:`py3:functools.wraps`
-   does on Python versions after 3.2.
+   This does exactly the same what the :func:`py3:functools.wraps` decorator
+   does on Python versions after 3.2 by using :func:`update_wrapper`
+   internally. It sets the ``__wrapped__`` attribute on what it decorates and
+   it doesn't raise an error if any of the attributes mentioned in ``assigned``
+   and ``updated`` are missing on ``wrapped`` object.
 
 
 Syntax compatibility

--- a/six.py
+++ b/six.py
@@ -808,9 +808,14 @@ if sys.version_info[:2] < (3, 3):
 _add_doc(reraise, """Reraise an exception.""")
 
 if sys.version_info[0:2] < (3, 4):
-    def update_wrapper(wrapper, wrapped,
-                       assigned=functools.WRAPPER_ASSIGNMENTS,
-                       updated=functools.WRAPPER_UPDATES):
+    # This does exactly the same what the :func:`py3:functools.update_wrapper`
+    # function does on Python versions after 3.2. It sets the ``__wrapped__``
+    # attribute on ``wrapper`` object and it doesn't raise an error if any of
+    # the attributes mentioned in ``assigned`` and ``updated`` are missing on
+    # ``wrapped`` object.
+    def _update_wrapper(wrapper, wrapped,
+                        assigned=functools.WRAPPER_ASSIGNMENTS,
+                        updated=functools.WRAPPER_UPDATES):
         for attr in assigned:
             try:
                 value = getattr(wrapped, attr)
@@ -822,16 +827,15 @@ if sys.version_info[0:2] < (3, 4):
             getattr(wrapper, attr).update(getattr(wrapped, attr, {}))
         wrapper.__wrapped__ = wrapped
         return wrapper
-    update_wrapper.__doc__ = functools.update_wrapper.__doc__
+    _update_wrapper.__doc__ = functools.update_wrapper.__doc__
 
     def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
               updated=functools.WRAPPER_UPDATES):
-        return functools.partial(update_wrapper, wrapped=wrapped,
+        return functools.partial(_update_wrapper, wrapped=wrapped,
                                  assigned=assigned, updated=updated)
     wraps.__doc__ = functools.wraps.__doc__
 
 else:
-    update_wrapper = functools.update_wrapper
     wraps = functools.wraps
 
 
@@ -933,7 +937,6 @@ def ensure_text(s, encoding='utf-8', errors='strict'):
         return s
     else:
         raise TypeError("not expecting type '%s'" % type(s))
-
 
 
 def python_2_unicode_compatible(klass):

--- a/test_six.py
+++ b/test_six.py
@@ -856,7 +856,7 @@ def test_wraps_raises_on_missing_updated_field_on_wrapper():
     def wrapper():
         pass
 
-    with py.test.raises(AttributeError, match='has no attribute.*xyzzy'):
+    with pytest.raises(AttributeError, match='has no attribute.*xyzzy'):
         six.wraps(wrapped, [], ['xyzzy'])(wrapper)
 
 

--- a/test_six.py
+++ b/test_six.py
@@ -832,14 +832,33 @@ def test_wraps():
     def f(g, assign, update):
         def w():
             return 42
-        w.glue = {"foo" : "bar"}
+        w.glue = {"foo": "bar"}
+        w.xyzzy = {"qux": "quux"}
         return six.wraps(g, assign, update)(w)
-    k.glue = {"melon" : "egg"}
+    k.glue = {"melon": "egg"}
     k.turnip = 43
-    k = f(k, ["turnip"], ["glue"])
+    k = f(k, ["turnip", "baz"], ["glue", "xyzzy"])
     assert k.__name__ == "w"
     assert k.turnip == 43
-    assert k.glue == {"melon" : "egg", "foo" : "bar"}
+    assert not hasattr(k, "baz")
+    assert k.glue == {"melon": "egg", "foo": "bar"}
+    assert k.xyzzy == {"qux": "quux"}
+
+
+def test_wraps_raises_on_missing_updated_field_on_wrapper():
+    """Ensure six.wraps doesn't ignore missing attrs wrapper.
+
+    Because that's what happens in Py3's functools.update_wrapper.
+    """
+    def wrapped():
+        pass
+
+    def wrapper():
+        pass
+
+    with py.test.raises(AttributeError, match='has no attribute.*xyzzy'):
+        six.wraps(wrapped, [], ['xyzzy'])(wrapper)
+
 
 
 def test_add_metaclass():


### PR DESCRIPTION
This PR should fix #250 and #165.

This is pretty-much a straight backport of Py3 implementations of `update_wrapper` and `wraps`, which is probably the easier way, but let me know if adding an extra public function `update_wrapper` should be avoided and this point and I'll fix it within `wraps` itself.