### PR TITLE
Be more precise about what six.class_types

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -50,8 +50,9 @@ Six provides constants that may differ between Python versions.  Ones ending
 
 .. data:: class_types
 
-   Possible class types.  In Python 2, this encompasses old-style and new-style
-   classes.  In Python 3, this is just new-styles.
+   Possible class types.  In Python 2, this encompasses old-style
+   :data:`py2:types.ClassType` and new-style ``type`` classes.  In Python 3,
+   this is just ``type``.
 
 
 .. data:: integer_types


### PR DESCRIPTION
Avoids the need for users to look this up by experimentation or code inspection.