### PR TITLE
Remove deprecated indexserver from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
 envlist=py26,py27,py31,py32,py33,py34,pypy,flake8
-indexserver=
-    default = https://pypi.org/simple
-    testrun = http://pypi.testrun.org
 
 [testenv]
 deps= pytest
@@ -12,4 +9,3 @@ commands= python -m pytest -rfsxX {posargs}
 basepython=python
 deps=flake8
 commands= flake8 six.py
-


### PR DESCRIPTION
https://tox.readthedocs.io/en/latest/config.html#confval-indexserver

> DEPRECATED, will be removed in a future version

Unnecessary anyway as all deps come from PyPI through pip.