### PR TITLE
Fix #259--if a class has a non-trivial qualname, make sure to copy it when adding a metaclass

### DIFF
--- a/six.py
+++ b/six.py
@@ -844,11 +844,9 @@ def add_metaclass(metaclass):
                 orig_vars.pop(slots_var)
         orig_vars.pop('__dict__', None)
         orig_vars.pop('__weakref__', None)
-        new_cls = metaclass(cls.__name__, cls.__bases__, orig_vars)
-        if hasattr(cls, '__qualname__') and cls.__qualname__ != cls.__name__:
-            new_cls.__qualname__ = cls.__qualname__
-
-        return new_cls
+        if hasattr(cls, '__qualname__'):
+            orig_vars['__qualname__'] = cls.__qualname__
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
     return wrapper
 
 

--- a/six.py
+++ b/six.py
@@ -844,7 +844,11 @@ def add_metaclass(metaclass):
                 orig_vars.pop(slots_var)
         orig_vars.pop('__dict__', None)
         orig_vars.pop('__weakref__', None)
-        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+        new_cls = metaclass(cls.__name__, cls.__bases__, orig_vars)
+        if hasattr(cls, '__qualname__') and cls.__qualname__ != cls.__name__:
+            new_cls.__qualname__ = cls.__qualname__
+
+        return new_cls
     return wrapper
 
 

--- a/test_six.py
+++ b/test_six.py
@@ -884,13 +884,15 @@ def test_add_metaclass_nested():
     class A:
         class B: pass
 
-    assert A.B.__qualname__.endswith('A.B')
+    expected = 'test_add_metaclass_nested.<locals>.A.B'
+
+    assert A.B.__qualname__ == expected
 
     class A:
         @six.add_metaclass(Meta)
         class B: pass
 
-    assert A.B.__qualname__.endswith('A.B')
+    assert A.B.__qualname__ == expected
 
 
 @py.test.mark.skipif("sys.version_info[:2] < (2, 7) or sys.version_info[:2] in ((3, 0), (3, 1))")

--- a/test_six.py
+++ b/test_six.py
@@ -875,6 +875,24 @@ def test_add_metaclass():
     assert type(MySlotsWeakref) is Meta
 
 
+@py.test.mark.skipif("sys.version_info[:2] < (3, 3)")
+def test_add_metaclass_nested():
+    # Regression test for https://github.com/benjaminp/six/issues/259
+    class Meta(type):
+        pass
+
+    class A:
+        class B: pass
+
+    assert A.B.__qualname__.endswith('A.B')
+
+    class A:
+        @six.add_metaclass(Meta)
+        class B: pass
+
+    assert A.B.__qualname__.endswith('A.B')
+
+
 @py.test.mark.skipif("sys.version_info[:2] < (2, 7) or sys.version_info[:2] in ((3, 0), (3, 1))")
 def test_assertCountEqual():
     class TestAssertCountEqual(unittest.TestCase):


### PR DESCRIPTION
Fixes #259.