### PR TITLE
Docs: reload() is in importlib in current Python 3

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -522,7 +522,7 @@ Python 2 or 3, write::
    from six.moves import html_parser
 
 Similarly, to get the function to reload modules, which was moved from the
-builtin module to the ``imp`` module, use::
+builtin module to the ``importlib`` module, use::
 
    from six.moves import reload_module
 


### PR DESCRIPTION
The docs say that the Python 2 builtin __reload()__ was moved into the __imp__ module (which _used_ to be true) but in all currently supported versions of CPython, __reload()__ is found in the __importlib__ module: https://docs.python.org/3/library/importlib.html#importlib.reload