### PR TITLE
Remove distutils fallback and outdated comment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,7 @@
 
 from __future__ import with_statement
 
-# Six is a dependency of setuptools, so using setuptools creates a
-# circular dependency when building a Python stack from source. We
-# therefore allow falling back to distutils to install six.
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 import six
 


### PR DESCRIPTION
setuptools includes a vendored version of six (and other dependencies).
They are not installed through traditional tools. Therefore, distutils
is not required as a fallback to facilitate setuptools.

https://github.com/pypa/setuptools/blob/v40.6.3/setuptools/_vendor/six.py