### PR TITLE
Document that binary_type is only necessary for Python 2.5 compat

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -76,7 +76,9 @@ Six provides constants that may differ between Python versions.  Ones ending
 .. data:: binary_type
 
    Type for representing binary data.  This is :func:`py2:str` in Python 2 and
-   :func:`py3:bytes` in Python 3.
+   :func:`py3:bytes` in Python 3.  Python 2.6 and 2.7 include ``bytes`` as a
+   builtin alias of ``str``, so six’s version is only necessary for Python 2.5
+   compatibility.
 
 
 .. data:: MAXSIZE


### PR DESCRIPTION
As documented in the Python 2.6 release notes:

https://docs.python.org/2/whatsnew/2.6.html#pep-3112-byte-literals

> For future compatibility, Python 2.6 adds bytes as a synonym for the str type ...

To encourage more forward compatible code bases, inform users of this builtin alias. This addition is similar in spirit to the note for the `b()` function.