### PR TITLE
Minor formatting fix. 📚

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -444,7 +444,7 @@ string data in all Python versions.
 
 .. function:: ensure_str(s, encoding='utf-8', errors='strict')
 
-   Coerce *s* to ``str``. ``encoding``, ``errors`` are the same
+   Coerce *s* to ``str``. *encoding*, *errors* are the same
    :meth:`py3:str.encode`
 
 


### PR DESCRIPTION
Small update to the `ensure_str` function's documentation formatting to
match `ensure_binary` and `ensure_text`'s formatting.

By the way, thank you for making the `ensure_*` methods. They are making my job much nicer. :+1: 