### PR TITLE
Travis CI: Start testing on Python 3.6, 3.7, and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 dist: trusty
-sudo: false
 language: python
 python:
 - 2.6
@@ -9,11 +8,18 @@ python:
 - 3.3
 - 3.4
 - 3.5
+- 3.6
 - &mainstream_python 3.6
-- 3.6-dev
-- 3.7-dev
 - pypy2.7-5.8.0
 - pypy3.5-5.8.0
+matrix:
+  allow_failures:
+  - python: nightly
+  include:
+  - python 3.7
+    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+  - python nightly
+    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)   
 install:
 - pip install --upgrade --force-reinstall "setuptools; python_version != '3.2' and python_version != '3.3'" "setuptools < 30; python_version == '3.2'" "setuptools < 40; python_version == '3.3'"
 - pip uninstall --yes six || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ jobs:
     dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
   - python: nightly
     dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-    allow_failures: true
   - stage: upload new version of python package to PYPI (only for tagged commits)
     python: *mainstream_python
     install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,6 @@ python:
 - &mainstream_python 3.6
 - pypy2.7-5.8.0
 - pypy3.5-5.8.0
-matrix:
-  allow_failures:
-  - python: nightly
-  include:
-  - python: 3.7
-    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-  - python: nightly
-    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)   
 install:
 - pip install --upgrade --force-reinstall "setuptools; python_version != '3.2' and python_version != '3.3'" "setuptools < 30; python_version == '3.2'" "setuptools < 40; python_version == '3.3'"
 - pip uninstall --yes six || true
@@ -34,7 +26,13 @@ script:
 - *py_pkg_list
 jobs:
   fast_finish: true
+  allow_failures:
+  - python: nightly
   include:
+  - python: 3.7
+    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+  - python: nightly
+    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)   
   - stage: upload new version of python package to PYPI (only for tagged commits)
     python: *mainstream_python
     install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ matrix:
   allow_failures:
   - python: nightly
   include:
-  - python 3.7
+  - python: 3.7
     dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-  - python nightly
+  - python: nightly
     dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)   
 install:
 - pip install --upgrade --force-reinstall "setuptools; python_version != '3.2' and python_version != '3.3'" "setuptools < 30; python_version == '3.2'" "setuptools < 40; python_version == '3.3'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,12 @@ script:
 - *py_pkg_list
 jobs:
   fast_finish: true
-  allow_failures:
-  - python: nightly
   include:
   - python: 3.7
     dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
   - python: nightly
-    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)   
+    dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+    allow_failures: true
   - stage: upload new version of python package to PYPI (only for tagged commits)
     python: *mainstream_python
     install: skip


### PR DESCRIPTION
Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).