### PR TITLE
Remove `six.io`

### DIFF
--- a/six.py
+++ b/six.py
@@ -637,6 +637,7 @@ if PY3:
     import io
     StringIO = io.StringIO
     BytesIO = io.BytesIO
+    del io
     _assertCountEqual = "assertCountEqual"
     if sys.version_info[1] <= 1:
         _assertRaisesRegex = "assertRaisesRegexp"


### PR DESCRIPTION
The existence of `six.io` seems error-prone to me.  It could be removed like `del struct` after `import struct` in the PY3 path.