### PR TITLE
Add various string conversion utilities

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -452,6 +452,30 @@ string data in all Python versions.
    :meth:`py3:str.encode`
 
 
+.. function:: str_to_binary(s, encoding='utf-8', errors='strict')
+
+   Encodes s to :data:`binary_type` in python 3 only. No-op in python 2.
+   *encoding*, *errors* are same as :meth:`py3.str.encode`
+
+
+.. function:: binary_to_str(s, encoding='utf-8', errors='strict')
+
+   Decodes s to ``str`` in python 3 only. No-op in python 2.
+   *encoding*, *errors* are same as :meth:`py3.str.encode`
+
+
+.. function:: str_to_text(s, encoding='utf-8', errors='strict')
+
+   Decodes s to :data:`text_type` in python 2 only. No-op in python 3.
+   *encoding*, *errors* are same as :meth:`py3.str.encode`
+
+
+.. function:: text_to_str(s, encoding='utf-8', errors='strict')
+
+   Encodes s to ``str`` in python 2 only. No-op in python 3.
+   *encoding*, *errors* are same as :meth:`py3.str.encode`
+
+
 .. data:: StringIO
 
    This is a fake file object for textual data.  It's an alias for

--- a/six.py
+++ b/six.py
@@ -908,6 +908,31 @@ def ensure_text(s, encoding='utf-8', errors='strict'):
         raise TypeError("not expecting type '%s'" % type(s))
 
 
+if PY3:
+    def binary_to_str(s, encoding='utf-8', errors='strict'):
+        return s.decode(encoding, errors)
+
+    def str_to_binary(s, encoding='utf-8', errors='strict'):
+        return s.encode(encoding, errors)
+
+    def text_to_str(s, encoding='utf-8', errors='strict'):
+        return s
+
+    def str_to_text(s, encoding='utf-8', errors='strict'):
+        return s
+else:
+    def binary_to_str(s, encoding='utf-8', errors='strict'):
+        return s
+
+    def str_to_binary(s, encoding='utf-8', errors='strict'):
+        return s
+
+    def text_to_str(s, encoding='utf-8', errors='strict'):
+        return s.encode('utf-8')
+
+    def str_to_text(s, encoding='utf-8', errors='strict'):
+        return s.decode('utf-8')
+
 
 def python_2_unicode_compatible(klass):
     """

--- a/test_six.py
+++ b/test_six.py
@@ -954,12 +954,23 @@ def test_python_2_unicode_compatible():
     assert getattr(six.moves.builtins, 'bytes', str)(my_test) == six.b("hello")
 
 
+# grinning face emoji
+UNICODE_EMOJI = six.u("\U0001F600")
+BINARY_EMOJI = b"\xf0\x9f\x98\x80"
+if six.PY2:
+    STR_EMOJI = BINARY_EMOJI
+else:
+    STR_EMOJI = UNICODE_EMOJI
+
+
+def test_str_conversions():
+    assert six.binary_to_str(BINARY_EMOJI) == STR_EMOJI
+    assert six.str_to_binary(STR_EMOJI) == BINARY_EMOJI
+    assert six.text_to_str(UNICODE_EMOJI) == STR_EMOJI
+    assert six.str_to_text(STR_EMOJI) == UNICODE_EMOJI
+
+
 class EnsureTests:
-
-    # grinning face emoji
-    UNICODE_EMOJI = six.u("\U0001F600")
-    BINARY_EMOJI = b"\xf0\x9f\x98\x80"
-
     def test_ensure_binary_raise_type_error(self):
         with py.test.raises(TypeError):
             six.ensure_str(8)


### PR DESCRIPTION
Currently six provides `ensure_str`, `ensure_text`, and `ensure_binary`. Typically these are used when you have a `str` object and want to convert to text or bytes, or the inverse.

I'd prefer to be explicit about which conversion I'm doing. For example, using `six.ensure_binary` should probably not be accepting text in py2 and should not be accepting binary in py3 (for most use cases). Effectively these equivalents make the code a little stricter about what types are actually expected.

They should also be more performant as they avoid an `isinstance` lookup on every conversion.