### PR TITLE
Fix for Python 4

### DIFF
--- a/six.py
+++ b/six.py
@@ -37,15 +37,7 @@ PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 PY34 = sys.version_info[0:2] >= (3, 4)
 
-if PY3:
-    string_types = str,
-    integer_types = int,
-    class_types = type,
-    text_type = str
-    binary_type = bytes
-
-    MAXSIZE = sys.maxsize
-else:
+if PY2:
     string_types = basestring,
     integer_types = (int, long)
     class_types = (type, types.ClassType)
@@ -70,6 +62,14 @@ else:
             # 64-bit
             MAXSIZE = int((1 << 63) - 1)
         del X
+else:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
 
 
 def _add_doc(func, doc):
@@ -104,12 +104,12 @@ class MovedModule(_LazyDescr):
 
     def __init__(self, name, old, new=None):
         super(MovedModule, self).__init__(name)
-        if PY3:
+        if PY2:
+            self.mod = old
+        else:
             if new is None:
                 new = name
             self.mod = new
-        else:
-            self.mod = old
 
     def _resolve(self):
         return _import_module(self.mod)
@@ -140,7 +140,12 @@ class MovedAttribute(_LazyDescr):
 
     def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
         super(MovedAttribute, self).__init__(name)
-        if PY3:
+        if PY2:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+        else:
             if new_mod is None:
                 new_mod = name
             self.mod = new_mod
@@ -150,11 +155,6 @@ class MovedAttribute(_LazyDescr):
                 else:
                     new_attr = old_attr
             self.attr = new_attr
-        else:
-            self.mod = old_mod
-            if old_attr is None:
-                old_attr = name
-            self.attr = old_attr
 
     def _resolve(self):
         module = _import_module(self.mod)
@@ -505,15 +505,7 @@ def remove_move(name):
             raise AttributeError("no such move, %r" % (name,))
 
 
-if PY3:
-    _meth_func = "__func__"
-    _meth_self = "__self__"
-
-    _func_closure = "__closure__"
-    _func_code = "__code__"
-    _func_defaults = "__defaults__"
-    _func_globals = "__globals__"
-else:
+if PY2:
     _meth_func = "im_func"
     _meth_self = "im_self"
 
@@ -521,6 +513,14 @@ else:
     _func_code = "func_code"
     _func_defaults = "func_defaults"
     _func_globals = "func_globals"
+else:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
 
 
 try:
@@ -538,17 +538,7 @@ except NameError:
         return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
 
 
-if PY3:
-    def get_unbound_function(unbound):
-        return unbound
-
-    create_bound_method = types.MethodType
-
-    def create_unbound_method(func, cls):
-        return func
-
-    Iterator = object
-else:
+if PY2:
     def get_unbound_function(unbound):
         return unbound.im_func
 
@@ -562,6 +552,16 @@ else:
 
         def next(self):
             return type(self).__next__(self)
+else:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
 
     callable = callable
 _add_doc(get_unbound_function,
@@ -576,25 +576,7 @@ get_function_defaults = operator.attrgetter(_func_defaults)
 get_function_globals = operator.attrgetter(_func_globals)
 
 
-if PY3:
-    def iterkeys(d, **kw):
-        return iter(d.keys(**kw))
-
-    def itervalues(d, **kw):
-        return iter(d.values(**kw))
-
-    def iteritems(d, **kw):
-        return iter(d.items(**kw))
-
-    def iterlists(d, **kw):
-        return iter(d.lists(**kw))
-
-    viewkeys = operator.methodcaller("keys")
-
-    viewvalues = operator.methodcaller("values")
-
-    viewitems = operator.methodcaller("items")
-else:
+if PY2:
     def iterkeys(d, **kw):
         return d.iterkeys(**kw)
 
@@ -612,6 +594,24 @@ else:
     viewvalues = operator.methodcaller("viewvalues")
 
     viewitems = operator.methodcaller("viewitems")
+else:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
 
 _add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
 _add_doc(itervalues, "Return an iterator over the values of a dictionary.")
@@ -621,7 +621,28 @@ _add_doc(iterlists,
          "Return an iterator over the (key, [values]) pairs of a dictionary.")
 
 
-if PY3:
+if PY2:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+else:
     def b(s):
         return s.encode("latin-1")
 
@@ -645,27 +666,9 @@ if PY3:
     else:
         _assertRaisesRegex = "assertRaisesRegex"
         _assertRegex = "assertRegex"
-else:
-    def b(s):
-        return s
-    # Workaround for standalone backslash
 
-    def u(s):
-        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
-    unichr = unichr
-    int2byte = chr
 
-    def byte2int(bs):
-        return ord(bs[0])
 
-    def indexbytes(buf, i):
-        return ord(buf[i])
-    iterbytes = functools.partial(itertools.imap, ord)
-    import StringIO
-    StringIO = BytesIO = StringIO.StringIO
-    _assertCountEqual = "assertItemsEqual"
-    _assertRaisesRegex = "assertRaisesRegexp"
-    _assertRegex = "assertRegexpMatches"
 _add_doc(b, """Byte literal""")
 _add_doc(u, """Text literal""")
 
@@ -682,21 +685,7 @@ def assertRegex(self, *args, **kwargs):
     return getattr(self, _assertRegex)(*args, **kwargs)
 
 
-if PY3:
-    exec_ = getattr(moves.builtins, "exec")
-
-    def reraise(tp, value, tb=None):
-        try:
-            if value is None:
-                value = tp()
-            if value.__traceback__ is not tb:
-                raise value.with_traceback(tb)
-            raise value
-        finally:
-            value = None
-            tb = None
-
-else:
+if PY2:
     def exec_(_code_, _globs_=None, _locs_=None):
         """Execute code in a namespace."""
         if _globs_ is None:
@@ -715,6 +704,20 @@ else:
     finally:
         tb = None
 """)
+
+else:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
 
 
 if sys.version_info[:2] == (3, 2):
@@ -885,7 +888,7 @@ def ensure_str(s, encoding='utf-8', errors='strict'):
         raise TypeError("not expecting type '%s'" % type(s))
     if PY2 and isinstance(s, text_type):
         s = s.encode(encoding, errors)
-    elif PY3 and isinstance(s, binary_type):
+    elif not PY2 and isinstance(s, binary_type):
         s = s.decode(encoding, errors)
     return s
 

--- a/test_six.py
+++ b/test_six.py
@@ -86,10 +86,10 @@ def test_MAXSIZE():
 
 
 def test_lazy():
-    if six.PY3:
-        html_name = "html.parser"
-    else:
+    if six.PY2:
         html_name = "HTMLParser"
+    else:
+        html_name = "html.parser"
     assert html_name not in sys.modules
     mod = six.moves.html_parser
     assert sys.modules[html_name] is mod
@@ -267,31 +267,31 @@ class TestCustomizedMoves:
 
     def test_moved_attribute(self):
         attr = six.MovedAttribute("spam", "foo", "bar")
-        if six.PY3:
-            assert attr.mod == "bar"
-        else:
+        if six.PY2:
             assert attr.mod == "foo"
+        else:
+            assert attr.mod == "bar"
         assert attr.attr == "spam"
         attr = six.MovedAttribute("spam", "foo", "bar", "lemma")
         assert attr.attr == "lemma"
         attr = six.MovedAttribute("spam", "foo", "bar", "lemma", "theorm")
-        if six.PY3:
-            assert attr.attr == "theorm"
-        else:
+        if six.PY2:
             assert attr.attr == "lemma"
+        else:
+            assert attr.attr == "theorm"
 
 
     def test_moved_module(self):
         attr = six.MovedModule("spam", "foo")
-        if six.PY3:
+        if six.PY2:
+            assert attr.mod == "foo"
+        else:
             assert attr.mod == "spam"
-        else:
-            assert attr.mod == "foo"
         attr = six.MovedModule("spam", "foo", "bar")
-        if six.PY3:
-            assert attr.mod == "bar"
-        else:
+        if six.PY2:
             assert attr.mod == "foo"
+        else:
+            assert attr.mod == "bar"
 
 
     def test_custom_move_module(self):
@@ -384,12 +384,12 @@ def test_dictionary_iterators(monkeypatch):
         """Given a method suffix like "lists" or "values", return the name
         of the dict method that delivers those on the version of Python
         we're running in."""
-        if six.PY3:
+        if not six.PY2:
             return iterwhat
         return 'iter' + iterwhat
 
     class MyDict(dict):
-        if not six.PY3:
+        if six.PY2:
             def lists(self, **kw):
                 return [1, 2, 3]
         def iterlists(self, **kw):
@@ -423,7 +423,7 @@ def test_dictionary_views():
         """Given a method suffix like "keys" or "values", return the name
         of the dict method that delivers those on the version of Python
         we're running in."""
-        if six.PY3:
+        if not six.PY2:
             return viewwhat
         return 'view' + viewwhat
 
@@ -496,21 +496,7 @@ def test_create_unbound_method():
     assert f(x) is x
 
 
-if six.PY3:
-
-    def test_b():
-        data = six.b("\xff")
-        assert isinstance(data, bytes)
-        assert len(data) == 1
-        assert data == bytes([255])
-
-
-    def test_u():
-        s = six.u("hi \u0439 \U00000439 \\ \\\\ \n")
-        assert isinstance(s, str)
-        assert s == "hi \u0439 \U00000439 \\ \\\\ \n"
-
-else:
+if six.PY2:
 
     def test_b():
         data = six.b("\xff")
@@ -523,6 +509,20 @@ else:
         s = six.u("hi \u0439 \U00000439 \\ \\\\ \n")
         assert isinstance(s, unicode)
         assert s == "hi \xd0\xb9 \xd0\xb9 \\ \\\\ \n".decode("utf8")
+
+else:
+
+    def test_b():
+        data = six.b("\xff")
+        assert isinstance(data, bytes)
+        assert len(data) == 1
+        assert data == bytes([255])
+
+
+    def test_u():
+        s = six.u("hi \u0439 \U00000439 \\ \\\\ \n")
+        assert isinstance(s, str)
+        assert s == "hi \u0439 \U00000439 \\ \\\\ \n"
 
 
 def test_u_escapes():
@@ -589,10 +589,10 @@ def test_exec_():
 
 def test_reraise():
     def get_next(tb):
-        if six.PY3:
-            return tb.tb_next.tb_next
-        else:
+        if six.PY2:
             return tb.tb_next
+        else:
+            return tb.tb_next.tb_next
     e = Exception("blah")
     try:
         raise e
@@ -947,7 +947,7 @@ def test_python_2_unicode_compatible():
     if six.PY2:
         assert str(my_test) == six.b("hello")
         assert unicode(my_test) == six.u("hello")
-    elif six.PY3:
+    else:
         assert bytes(my_test) == six.b("hello")
         assert str(my_test) == six.u("hello")
 


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and as six is vendored and used in many codebases, it would be good for six to be ready for both.

There's several places in the codebase which essentially do:

```python
if sys.version_info[0] == 3:
   pass  # Python 3+ stuff
else:
   pass  # Python 2 stuff
```

When run on Python 4, this will run the Python 2 code!

This PR flips it around:

```python
if sys.version_info[0] == 2:
   pass  # Python 2 stuff
else:
   pass  # Python 3+ stuff
```

Thanks to @asottile for [flake8-2020](https://github.com/asottile/flake8-2020).

---

As an aside, there's a slight inconsistency here:

```python
# Useful for very coarse version differentiation.
PY2 = sys.version_info[0] == 2
PY3 = sys.version_info[0] == 3
PY34 = sys.version_info[0:2] >= (3, 4)
```

`PY34` is true on Python 4, but `PY3` is not. Would it be too big a break to change it?

```diff
-PY3 = sys.version_info[0] == 3
+PY3 = sys.version_info[0] >= 3
```
