### PR TITLE
Revert "Remove distutils fallback and outdated comment (#269)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,13 @@
 
 from __future__ import with_statement
 
-from setuptools import setup
+# Six is a dependency of setuptools, so using setuptools creates a
+# circular dependency when building a Python stack from source. We
+# therefore allow falling back to distutils to install six.
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 import six
 


### PR DESCRIPTION
This reverts commit d5efa74e2dfde8d4ddba13e127cd85c687e6016b.

The original intention of providing a distutils fallback has not gone away. These three extra lines will almost never be used, as most people have setuptools or install with pip anyway, and at the same time it serves as a very low-maintenance solution for people who *do* want to bootstrap setuptools.

Bootstrapping setuptools without vendored six (and pyparsing) is a valid use case. Although setuptools by default ships with vendored dependencies, it supports removing the contents of the _vendored/ directory and falling back to an installed version of six.py -- and thirdparty vendors of setuptools, such as Arch Linux and OpenSUSE, actually make use of this and need to be able to bootstrap the dependency tree of setuptools itself.

@jaraco @jdufresne

See also https://github.com/pyparsing/pyparsing/pull/133