### PR TITLE
Add support for PEP 560

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - pip install --upgrade --force-reinstall "setuptools; python_version != '3.2' and python_version != '3.3'" "setuptools < 30; python_version == '3.2'" "setuptools < 40; python_version == '3.3'"
 - pip uninstall --yes six || true
 - pip install --upgrade --force-reinstall --ignore-installed -e .
-- pip install pytest, typing
+- pip install pytest typing
 - &py_pkg_list pip list --format=columns || pip list
 script:
 - py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - pip install --upgrade --force-reinstall "setuptools; python_version != '3.2' and python_version != '3.3'" "setuptools < 30; python_version == '3.2'" "setuptools < 40; python_version == '3.3'"
 - pip uninstall --yes six || true
 - pip install --upgrade --force-reinstall --ignore-installed -e .
-- pip install pytest
+- pip install pytest, typing
 - &py_pkg_list pip list --format=columns || pip list
 script:
 - py.test

--- a/six.py
+++ b/six.py
@@ -825,7 +825,15 @@ def with_metaclass(meta, *bases):
     class metaclass(type):
 
         def __new__(cls, name, this_bases, d):
-            return meta(name, bases, d)
+            if sys.version_info[:2] >= (3, 7):
+                # This version introduced PEP 560 that requires a bit
+                # of extra care (we mimic what is done by __build_class__).
+                resolved_bases = types.resolve_bases(bases)
+                if resolved_bases is not bases:
+                    d['__orig_bases__'] = bases
+            else:
+                resolved_bases = bases
+            return meta(name, resolved_bases, d)
 
         @classmethod
         def __prepare__(cls, name, this_bases):

--- a/test_six.py
+++ b/test_six.py
@@ -752,7 +752,7 @@ def test_with_metaclass_typing():
         py.test.skip("typing module required")
     class Meta(type):
         pass
-    if sys.version_info < (3, 7):
+    if sys.version_info[:2] < (3, 7):
         # Generics with custom metaclasses were broken on older versions.
         class Meta(Meta, typing.GenericMeta):
             pass

--- a/test_six.py
+++ b/test_six.py
@@ -745,6 +745,7 @@ def test_with_metaclass():
     assert Y.__mro__ == (Y, X, object)
 
 
+@py.test.mark.skipif("sys.version_info[:2] < (2, 7)")
 def test_with_metaclass_typing():
     try:
         import typing

--- a/test_six.py
+++ b/test_six.py
@@ -22,6 +22,7 @@ import operator
 import sys
 import types
 import unittest
+import abc
 
 import py
 
@@ -742,6 +743,19 @@ def test_with_metaclass():
         pass
     assert type(Y) is MetaSub
     assert Y.__mro__ == (Y, X, object)
+    if sys.version_info[:2] >= (3, 7):
+        from typing import Generic, TypeVar
+        T = TypeVar('T')
+        class G(six.with_metaclass(Meta, Generic[T])):
+            pass
+        class GA(six.with_metaclass(abc.ABCMeta, Generic[T])):
+            pass
+        assert isinstance(G, Meta)
+        assert isinstance(GA, abc.ABCMeta)
+        assert G[int] is not G[G[int]]
+        assert GA[int] is not GA[GA[int]]
+        assert G.__bases__ == (Generic,)
+        assert G.__orig_bases__ == (Generic[T],)
 
 
 @py.test.mark.skipif("sys.version_info[:2] < (3, 0)")

--- a/test_six.py
+++ b/test_six.py
@@ -743,19 +743,23 @@ def test_with_metaclass():
         pass
     assert type(Y) is MetaSub
     assert Y.__mro__ == (Y, X, object)
-    if sys.version_info[:2] >= (3, 7):
-        from typing import Generic, TypeVar
-        T = TypeVar('T')
-        class G(six.with_metaclass(Meta, Generic[T])):
+    if sys.version_info[:2] >= (3, 5):
+        import typing
+        T = typing.TypeVar('T')
+        if sys.version_info < (3, 7):
+            # Generics with custom metaclasses were broken on older versions.
+            class Meta(Meta, typing.GenericMeta):
+                pass
+        class G(six.with_metaclass(Meta, typing.Generic[T])):
             pass
-        class GA(six.with_metaclass(abc.ABCMeta, Generic[T])):
+        class GA(six.with_metaclass(abc.ABCMeta, typing.Generic[T])):
             pass
         assert isinstance(G, Meta)
         assert isinstance(GA, abc.ABCMeta)
         assert G[int] is not G[G[int]]
         assert GA[int] is not GA[GA[int]]
-        assert G.__bases__ == (Generic,)
-        assert G.__orig_bases__ == (Generic[T],)
+        assert G.__bases__ == (typing.Generic,)
+        assert G.__orig_bases__ == (typing.Generic[T],)
 
 
 @py.test.mark.skipif("sys.version_info[:2] < (3, 0)")

--- a/test_six.py
+++ b/test_six.py
@@ -743,23 +743,30 @@ def test_with_metaclass():
         pass
     assert type(Y) is MetaSub
     assert Y.__mro__ == (Y, X, object)
-    if sys.version_info[:2] >= (3, 5):
+
+
+def test_with_metaclass_typing():
+    try:
         import typing
-        T = typing.TypeVar('T')
-        if sys.version_info < (3, 7):
-            # Generics with custom metaclasses were broken on older versions.
-            class Meta(Meta, typing.GenericMeta):
-                pass
-        class G(six.with_metaclass(Meta, typing.Generic[T])):
+    except ImportError:
+        py.test.skip("typing module required")
+    class Meta(type):
+        pass
+    if sys.version_info < (3, 7):
+        # Generics with custom metaclasses were broken on older versions.
+        class Meta(Meta, typing.GenericMeta):
             pass
-        class GA(six.with_metaclass(abc.ABCMeta, typing.Generic[T])):
-            pass
-        assert isinstance(G, Meta)
-        assert isinstance(GA, abc.ABCMeta)
-        assert G[int] is not G[G[int]]
-        assert GA[int] is not GA[GA[int]]
-        assert G.__bases__ == (typing.Generic,)
-        assert G.__orig_bases__ == (typing.Generic[T],)
+    T = typing.TypeVar('T')
+    class G(six.with_metaclass(Meta, typing.Generic[T])):
+        pass
+    class GA(six.with_metaclass(abc.ABCMeta, typing.Generic[T])):
+        pass
+    assert isinstance(G, Meta)
+    assert isinstance(GA, abc.ABCMeta)
+    assert G[int] is not G[G[int]]
+    assert GA[int] is not GA[GA[int]]
+    assert G.__bases__ == (typing.Generic,)
+    assert G.__orig_bases__ == (typing.Generic[T],)
 
 
 @py.test.mark.skipif("sys.version_info[:2] < (3, 0)")

--- a/test_six.py
+++ b/test_six.py
@@ -770,6 +770,28 @@ def test_with_metaclass_typing():
     assert G.__orig_bases__ == (typing.Generic[T],)
 
 
+@py.test.mark.skipif("sys.version_info[:2] < (3, 7)")
+def test_with_metaclass_pep_560():
+    class Meta(type):
+        pass
+    class A:
+        pass
+    class B:
+        pass
+    class Fake:
+        def __mro_entries__(self, bases):
+            return (A, B)
+    fake = Fake()
+    class G(six.with_metaclass(Meta, fake)):
+        pass
+    class GA(six.with_metaclass(abc.ABCMeta, fake)):
+        pass
+    assert isinstance(G, Meta)
+    assert isinstance(GA, abc.ABCMeta)
+    assert G.__bases__ == (A, B)
+    assert G.__orig_bases__ == (fake,)
+
+
 @py.test.mark.skipif("sys.version_info[:2] < (3, 0)")
 def test_with_metaclass_prepare():
     """Test that with_metaclass causes Meta.__prepare__ to be called with the correct arguments."""


### PR DESCRIPTION
This is mostly important for `typing` module that is extensively using PEP 560 since Python 3.7. The goal of this PR is to make
```python
class G(six.with_metaclass(ABCMeta, Generic[T])):
    ...
```
behave equivalently to
```python
class G(Generic[T], metaclass=ABCMeta):
    ...
```
and
```python
class G(Generic[T]):
    __metaclass__ = ABCMeta
```
on all Python versions (also with custom metaclasses on Python versions where it is supported).