### PR TITLE
add six.html_escape() due to removal of cgi.escape() in 3.8

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -873,3 +873,18 @@ have any public members.
    attributes in Python 2 and 3.  *old_mod* is the name of the Python 2 module.
    *new_mod* is the name of the Python 3 module.  If *new_attr* is not given, it
    defaults to *old_attr*.  If neither is given, they both default to *name*.
+
+
+Deprecated and Removed Modules and Attributes
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+.. function:: html_escape(s, quote=True)
+
+    :func:`py2:cgi.escape` was deprecated in version 3.7 and is no longer
+    available in versions 3.8+.  The intended replacement is
+    :func:`py3:html.escape`, which differs in two ways:
+
+    1. The default value for the *quote* parameter is ``True`` rather than
+       ``False``.
+    2. When *quote* is ``True``, single quote characters (``'``) are also
+       quoted.

--- a/six.py
+++ b/six.py
@@ -938,6 +938,18 @@ def python_2_unicode_compatible(klass):
     return klass
 
 
+if sys.version_info[:2] >= (3, 2):
+    import html
+    def html_escape(s, quote=True):
+        return html.escape(s, quote)
+else:
+    import cgi
+    def html_escape(s, quote=True):
+        escaped = cgi.escape(s, quote)
+        if quote:
+            escaped = escaped.replace("'", "&#x27;")
+        return escaped
+
 # Complete the moves implementation.
 # This code is at the end of this module to speed up module loading.
 # Turn this module into a package.

--- a/test_six.py
+++ b/test_six.py
@@ -1002,6 +1002,13 @@ def test_python_2_unicode_compatible():
     assert getattr(six.moves.builtins, 'bytes', str)(my_test) == six.b("hello")
 
 
+def test_html_escape():
+    assert six.html_escape('\'<div>"&something;"</div>\'') == \
+        '&#x27;&lt;div&gt;&quot;&amp;something;&quot;&lt;/div&gt;&#x27;'
+    assert six.html_escape('\'<div>"&something;"</div>\'', False) == \
+        '\'&lt;div&gt;"&amp;something;"&lt;/div&gt;\''
+
+
 class EnsureTests:
 
     # grinning face emoji


### PR DESCRIPTION
Closes #159.

Note that this is not a simple move, since `cgi.escape()` has `False` rather than `True` as the default for the *quote* parameter, and it also doesn't quote single quote characters (`'`) when *quote* is True.

The tests are based on those for `html.escape` [in the CPython test suite](https://github.com/python/cpython/blob/5c0c325453a175350e3c18ebb10cc10c37f9595c/Lib/test/test_html.py).