### PR TITLE
Drop support for EOL Python 2.6 and 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 - pypy
 - pypy3
 install:
-- pip install --upgrade --force-reinstall "setuptools; python_version != '3.2' and python_version != '3.3'" "setuptools < 30; python_version == '3.2'" "setuptools < 40; python_version == '3.3'"
+- pip install --upgrade --force-reinstall "setuptools; python_version != '3.3'" "setuptools < 40; python_version == '3.3'"
 - pip uninstall --yes six || true
 - pip install --upgrade --force-reinstall --ignore-installed -e .
 - pip install pytest==2.9.2 typing
@@ -26,10 +26,6 @@ script:
 jobs:
   fast_finish: true
   include:
-  - python: 2.6
-    dist: trusty
-  - python: 3.2
-    dist: trusty
   - python: 3.3
     dist: trusty
   - stage: upload new version of python package to PYPI (only for tagged commits)

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ for smoothing over the differences between the Python versions with the goal of
 writing Python code that is compatible on both Python versions.  See the
 documentation for more information on what is provided.
 
-Six supports every Python version since 2.6.  It is contained in only one Python
+Six supports Python 2.7 and 3.3+.  It is contained in only one Python
 file, so it can be easily copied into your project. (The copyright and license
 notice must be retained.)
 

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(name="six",
       long_description=six_long_description,
       license="MIT",
       classifiers=six_classifiers,
-      python_requires=">=2.6, !=3.0.*, !=3.1.*",
+      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*",
       )

--- a/six.py
+++ b/six.py
@@ -719,16 +719,7 @@ else:
 """)
 
 
-if sys.version_info[:2] == (3, 2):
-    exec_("""def raise_from(value, from_value):
-    try:
-        if from_value is None:
-            raise value
-        raise value from from_value
-    finally:
-        value = None
-""")
-elif sys.version_info[:2] > (3, 2):
+if sys.version_info[:2] > (3,):
     exec_("""def raise_from(value, from_value):
     try:
         raise value from from_value

--- a/test_six.py
+++ b/test_six.py
@@ -121,34 +121,23 @@ def test_move_items(item_name):
         item = getattr(six.moves, item_name)
         if isinstance(item, types.ModuleType):
             __import__("six.moves." + item_name)
-    except AttributeError:
-        if item_name == "zip_longest" and sys.version_info < (2, 6):
-            pytest.skip("zip_longest only available on 2.6+")
     except ImportError:
         if item_name == "winreg" and not sys.platform.startswith("win"):
             pytest.skip("Windows only module")
         if item_name.startswith("tkinter"):
             if not have_tkinter:
                 pytest.skip("requires tkinter")
-            if item_name == "tkinter_ttk" and sys.version_info[:2] <= (2, 6):
-                pytest.skip("ttk only available on 2.7+")
         if item_name.startswith("dbm_gnu") and not have_gdbm:
             pytest.skip("requires gdbm")
         raise
-    if sys.version_info[:2] >= (2, 6):
-        assert item_name in dir(six.moves)
+    assert item_name in dir(six.moves)
 
 
 @pytest.mark.parametrize("item_name",
                           [item.name for item in six._urllib_parse_moved_attributes])
 def test_move_items_urllib_parse(item_name):
     """Ensure that everything loads correctly."""
-    if item_name == "ParseResult" and sys.version_info < (2, 5):
-        pytest.skip("ParseResult is only found on 2.5+")
-    if item_name in ("parse_qs", "parse_qsl") and sys.version_info < (2, 6):
-        pytest.skip("parse_qs[l] is new in 2.6")
-    if sys.version_info[:2] >= (2, 6):
-        assert item_name in dir(six.moves.urllib.parse)
+    assert item_name in dir(six.moves.urllib.parse)
     getattr(six.moves.urllib.parse, item_name)
 
 
@@ -156,8 +145,7 @@ def test_move_items_urllib_parse(item_name):
                           [item.name for item in six._urllib_error_moved_attributes])
 def test_move_items_urllib_error(item_name):
     """Ensure that everything loads correctly."""
-    if sys.version_info[:2] >= (2, 6):
-        assert item_name in dir(six.moves.urllib.error)
+    assert item_name in dir(six.moves.urllib.error)
     getattr(six.moves.urllib.error, item_name)
 
 
@@ -165,8 +153,7 @@ def test_move_items_urllib_error(item_name):
                           [item.name for item in six._urllib_request_moved_attributes])
 def test_move_items_urllib_request(item_name):
     """Ensure that everything loads correctly."""
-    if sys.version_info[:2] >= (2, 6):
-        assert item_name in dir(six.moves.urllib.request)
+    assert item_name in dir(six.moves.urllib.request)
     getattr(six.moves.urllib.request, item_name)
 
 
@@ -174,8 +161,7 @@ def test_move_items_urllib_request(item_name):
                           [item.name for item in six._urllib_response_moved_attributes])
 def test_move_items_urllib_response(item_name):
     """Ensure that everything loads correctly."""
-    if sys.version_info[:2] >= (2, 6):
-        assert item_name in dir(six.moves.urllib.response)
+    assert item_name in dir(six.moves.urllib.response)
     getattr(six.moves.urllib.response, item_name)
 
 
@@ -183,8 +169,7 @@ def test_move_items_urllib_response(item_name):
                           [item.name for item in six._urllib_robotparser_moved_attributes])
 def test_move_items_urllib_robotparser(item_name):
     """Ensure that everything loads correctly."""
-    if sys.version_info[:2] >= (2, 6):
-        assert item_name in dir(six.moves.urllib.robotparser)
+    assert item_name in dir(six.moves.urllib.robotparser)
     getattr(six.moves.urllib.robotparser, item_name)
 
 
@@ -244,7 +229,6 @@ def test_zip():
     assert six.advance_iterator(zip(range(2), range(2))) == (0, 0)
 
 
-@pytest.mark.skipif("sys.version_info < (2, 6)")
 def test_zip_longest():
     from six.moves import zip_longest
     it = zip_longest(range(2), range(1))
@@ -417,8 +401,6 @@ def test_dictionary_iterators(monkeypatch):
         monkeypatch.undo()
 
 
-@pytest.mark.skipif("sys.version_info[:2] < (2, 7)",
-                reason="view methods on dictionaries only available on 2.7+")
 def test_dictionary_views():
     d = dict(zip(range(10), (range(11, 20))))
     for name in "keys", "values", "items":
@@ -636,7 +618,6 @@ def test_raise_from():
         # We should have done a raise f from None equivalent.
         assert val.__cause__ is None
         assert val.__context__ is ctx
-    if sys.version_info[:2] >= (3, 3):
         # And that should suppress the context on the exception.
         assert val.__suppress_context__
     # For all versions the outer exception should have raised successfully.
@@ -682,24 +663,6 @@ def test_print_():
     assert out.flushed
 
 
-@pytest.mark.skipif("sys.version_info[:2] >= (2, 6)")
-def test_print_encoding(monkeypatch):
-    # Fool the type checking in print_.
-    monkeypatch.setattr(six, "file", six.BytesIO, raising=False)
-    out = six.BytesIO()
-    out.encoding = "utf-8"
-    out.errors = None
-    six.print_(six.u("\u053c"), end="", file=out)
-    assert out.getvalue() == six.b("\xd4\xbc")
-    out = six.BytesIO()
-    out.encoding = "ascii"
-    out.errors = "strict"
-    pytest.raises(UnicodeEncodeError, six.print_, six.u("\u053c"), file=out)
-    out.errors = "backslashreplace"
-    six.print_(six.u("\u053c"), end="", file=out)
-    assert out.getvalue() == six.b("\\u053c")
-
-
 def test_print_exceptions():
     pytest.raises(TypeError, six.print_, x=3)
     pytest.raises(TypeError, six.print_, end=3)
@@ -737,7 +700,6 @@ def test_with_metaclass():
     assert Y.__mro__ == (Y, X, object)
 
 
-@pytest.mark.skipif("sys.version_info[:2] < (2, 7)")
 def test_with_metaclass_typing():
     try:
         import typing
@@ -935,7 +897,6 @@ def test_add_metaclass_nested():
     assert A.B.__qualname__ == expected
 
 
-@pytest.mark.skipif("sys.version_info[:2] < (2, 7) or sys.version_info[:2] in ((3, 0), (3, 1))")
 def test_assertCountEqual():
     class TestAssertCountEqual(unittest.TestCase):
         def test(self):
@@ -947,7 +908,6 @@ def test_assertCountEqual():
     TestAssertCountEqual('test').test()
 
 
-@pytest.mark.skipif("sys.version_info[:2] < (2, 7)")
 def test_assertRegex():
     class TestAssertRegex(unittest.TestCase):
         def test(self):
@@ -959,7 +919,6 @@ def test_assertRegex():
     TestAssertRegex('test').test()
 
 
-@pytest.mark.skipif("sys.version_info[:2] < (2, 7)")
 def test_assertRaisesRegex():
     class TestAssertRaisesRegex(unittest.TestCase):
         def test(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py32,py33,py34,py35,py36,py37,py38,pypy,flake8
+envlist=py27,py33,py34,py35,py36,py37,py38,pypy,flake8
 
 [testenv]
 deps= pytest


### PR DESCRIPTION
Fixes #308.

Stops testing them on the CI, update `python_requries` and remove some code specifically for those versions.

Not done anything to remove any six functionality that's only a benefit on those versions, that should be in a separate PR and would be a breaking change that should ideally deprecate first.
