### PR TITLE
[DOCS] Fix ensure_text docs

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -452,7 +452,7 @@ string data in all Python versions.
 .. function:: ensure_text(s, encoding='utf-8', errors='strict')
 
    Coerce *s* to :data:`text_type`. *encoding*, *errors* are the same as
-   :meth:`py2:str.decode`
+   :meth:`py3:bytes.decode`
 
 
 .. data:: StringIO

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -452,7 +452,7 @@ string data in all Python versions.
 .. function:: ensure_text(s, encoding='utf-8', errors='strict')
 
    Coerce *s* to :data:`text_type`. *encoding*, *errors* are the same as
-   :meth:`py3:str.encode`
+   :meth:`py2:str.decode`
 
 
 .. data:: StringIO


### PR DESCRIPTION
The method `ensure_text` is obviously using the `decode` method of `str` (py2) or `bytes` (py3), not the `encode` method.