### PR TITLE
Optimize ensure_str and ensure_binary.

### DIFF
--- a/six.py
+++ b/six.py
@@ -892,7 +892,7 @@ def ensure_binary(s, encoding='utf-8', errors='strict'):
     """
     if isinstance(s, binary_type):
         return s
-    elif isinstance(s, text_type):
+    if isinstance(s, text_type):
         return s.encode(encoding, errors)
     else:
         raise TypeError("not expecting type '%s'" % type(s))
@@ -909,11 +909,7 @@ def ensure_str(s, encoding='utf-8', errors='strict'):
       - `str` -> `str`
       - `bytes` -> decoded to `str`
     """
-    # Optimization: fast return for the common case. Improves performance
-    # by ~2-2.5x in Python 2 or 1.4-1.7x in Py3 for the case where
-    # s is a str. The uncommon case (unicode in 2, bytes in 3), ends up
-    # being around the same. The case that suffers is a subclass, or when
-    # an exception is thrown. Those are about 15-20% slower.
+    # Optimization: Fast return for the common case.
     if type(s) is str:
         return s
     if PY2 and isinstance(s, text_type):

--- a/six.py
+++ b/six.py
@@ -894,8 +894,7 @@ def ensure_binary(s, encoding='utf-8', errors='strict'):
         return s
     if isinstance(s, text_type):
         return s.encode(encoding, errors)
-    else:
-        raise TypeError("not expecting type '%s'" % type(s))
+    raise TypeError("not expecting type '%s'" % type(s))
 
 
 def ensure_str(s, encoding='utf-8', errors='strict'):


### PR DESCRIPTION
We found that large applications that have undergone a 2 -> 3 migration
and wound up with a lot of six.ensure_str and six.ensure_binary calls
could save 1-2% CPU usage by optimizing these for the common case.

Further optimization could be done by replacing them with extension
module implementations - assumed out of scope for the pure Python six
project itself.

Ideally all of these calls and use of six in people's code would be
removed after there all need for any Python 2 compatibility is gone.
But completing that kind of type cleanup requires a lot of human
engineering time.  This lowers the ongoing costs in the interim.

Contributed by YouTube.