### PR TITLE
Fix #60 Using raw_unicode_escape instead of unicode_escape

### DIFF
--- a/six.py
+++ b/six.py
@@ -655,7 +655,8 @@ else:
     # Workaround for standalone backslash
 
     def u(s):
-        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+        return unicode(s, "raw_unicode_escape")
+
     unichr = unichr
     int2byte = chr
 

--- a/test_six.py
+++ b/test_six.py
@@ -499,6 +499,15 @@ else:
         assert isinstance(s, unicode)
         assert s == "hi \xd0\xb9 \xd0\xb9 \\ \\\\ \n".decode("utf8")
 
+    def test_u_ending_with_backslash():
+        s = six.u("hi \u0439 \U00000439 \\")
+        assert isinstance(s, unicode)
+        assert s == "hi \xd0\xb9 \xd0\xb9 \\".decode("utf8")
+
+        s = six.u("hi \u0439 \U00000439 \\\\")
+        assert isinstance(s, unicode)
+        assert s == "hi \xd0\xb9 \xd0\xb9 \\\\".decode("utf8")
+
 
 def test_u_escapes():
     s = six.u("\u1234")


### PR DESCRIPTION
Using raw_unicode_escape instead of unicode_escape in order to be compatible with strings ending with backslash on python 2.7