### PR TITLE
New utility: is_bound_method

### DIFF
--- a/six.py
+++ b/six.py
@@ -541,6 +541,9 @@ except NameError:
 
 
 if PY3:
+    def is_bound_method(func):
+        return callable(func) and hasattr(func, _meth_self)
+
     def get_unbound_function(unbound):
         return unbound
 
@@ -551,6 +554,15 @@ if PY3:
 
     Iterator = object
 else:
+    _builtin_bound_method_type = type((0).bit_length)
+    _method_wrapper_type = type((0).__abs__)
+
+    def is_bound_method(func):
+        return (
+            callable(func) and getattr(func, _meth_self, None) is not None
+            or isinstance(func, (_builtin_bound_method_type, _method_wrapper_type))
+        )
+
     def get_unbound_function(unbound):
         return unbound.im_func
 

--- a/test_six.py
+++ b/test_six.py
@@ -471,6 +471,57 @@ def test_create_unbound_method():
     assert f(x) is x
 
 
+class TestIsBoundMethod:
+    class DummyClass:
+        @staticmethod
+        def static():
+            pass
+
+        @classmethod
+        def class_meth(cls):
+            pass
+
+        def meth(self):
+            pass
+
+    def a_free_function(self):
+        pass
+
+    @pytest.mark.parametrize(
+        "meth",
+        [
+            DummyClass().meth,
+            DummyClass.class_meth,
+            DummyClass().class_meth,
+            (0).bit_length,
+            "".join,
+            "foo".__lt__,
+            (0).__abs__,
+        ]
+    )
+    def test_is_bound_method_true(self, meth):
+        assert six.is_bound_method(meth)
+
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            lambda x: x,
+            a_free_function,
+            DummyClass.meth,
+            DummyClass.static,
+            DummyClass().static,
+            int.bit_length,
+            str.join,
+            str.__lt__,
+        ]
+    )
+    def test_is_bound_method_false(self, obj):
+        assert not six.is_bound_method(obj)
+
+    del DummyClass
+    del a_free_function
+
+
 if six.PY3:
 
     def test_b():


### PR DESCRIPTION
The behaviour of `inspect.ismethod` is inconsistent between Python 3 and 2. In Python 3, it returns `True` only for bound methods (since there's no way to tell whether a function object is an unbound method), while in Python 2 it returns `True` for both bound and unbound.

This PR adds an `is_bound_method` utility which returns `True` iff the object is callable and is a bound method (either instance- or class-).

Also added tests for this.