### PR TITLE
Json exception

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -850,7 +850,7 @@ JSON JSONDecodeError Exception
 
 The Python3 *json* module raises the JSONDecodeError exception when it can't
 decode the given json input. The Python2 *json* module raises the ValueError
-exception under the same cicumstances.
+exception under the same circumstances.
 
 .. data:: JSONDecodeError
 

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -843,6 +843,21 @@ Contains classes from Python 3's :mod:`py3:urllib.response` and Python 2's:
 * :class:`py2:urllib.addinfourl`
 
 
+JSON JSONDecodeError Exception
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+.. currentmodule:: six
+
+The Python3 *json* module raises the JSONDecodeError exception when it can't
+decode the given json input. The Python2 *json* module raises the ValueError
+exception under the same cicumstances.
+
+.. data:: JSONDecodeError
+
+   A JSONDecodeError exception that can be used to catch exceptions raised by
+   both the Python2 and Python3 *json* modules.
+
+
 Advanced - Customizing renames
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 

--- a/six.py
+++ b/six.py
@@ -45,6 +45,7 @@ if PY3:
     binary_type = bytes
 
     MAXSIZE = sys.maxsize
+    from json import JSONDecodeError
 else:
     string_types = basestring,
     integer_types = (int, long)
@@ -70,6 +71,7 @@ else:
             # 64-bit
             MAXSIZE = int((1 << 63) - 1)
         del X
+    JSONDecodeError = ValueError
 
 
 def _add_doc(func, doc):

--- a/test_six.py
+++ b/test_six.py
@@ -1039,3 +1039,11 @@ class EnsureTests:
             assert converted_unicode == self.UNICODE_EMOJI and isinstance(converted_unicode, str)
             # PY3: bytes -> str
             assert converted_binary == self.UNICODE_EMOJI and isinstance(converted_unicode, str)
+
+def test_JSONDecodeError():
+    import json
+    from six import JSONDecodeError
+    try:
+        json.loads('')
+    except JSONDecodeError:
+        pass


### PR DESCRIPTION
The Python3 json module raises JSONDecodeError where the Python2 json module raises ValueError. Added six.JSONDecodeError that can be used to catch the exception regardless of version.