### PR TITLE
Implement find_spec() for _SixMetaPathImporter

### DIFF
--- a/six.py
+++ b/six.py
@@ -71,6 +71,11 @@ else:
             MAXSIZE = int((1 << 63) - 1)
         del X
 
+if PY34:
+    from importlib.util import spec_from_loader
+else:
+    spec_from_loader = None
+
 
 def _add_doc(func, doc):
     """Add documentation to a function."""
@@ -184,6 +189,11 @@ class _SixMetaPathImporter(object):
     def find_module(self, fullname, path=None):
         if fullname in self.known_modules:
             return self
+        return None
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.known_modules:
+            return spec_from_loader(fullname, self)
         return None
 
     def __get_module(self, fullname):


### PR DESCRIPTION
This  is in preparation for `find_module()` to start raising `ImportWarning` in Python 3.10.

Closes #349