### PR TITLE
docs: fix typo in CHANGES

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -233,7 +233,7 @@ Development version
 - Issue #40: Add import mapping for the Python 2 gdbm module.
 
 - Issue #35: On Python versions less than 2.7, print_ now encodes unicode
-  strings when outputing to standard streams. (Python 2.7 handles this
+  strings when outputting to standard streams. (Python 2.7 handles this
   automatically.)
 
 1.4.1


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `CHANGES`



Best! :robot: