### PR TITLE
tkinter.tix was removed from Python 3.13, skip the test

### DIFF
--- a/test_six.py
+++ b/test_six.py
@@ -136,6 +136,8 @@ def test_move_items(item_name):
         if item_name.startswith("tkinter"):
             if not have_tkinter:
                 pytest.skip("requires tkinter")
+            if item_name == "tkinter_tix" and sys.version_info >= (3, 13):
+                pytest.skip("tkinter.tix removed from Python 3.13")
         if item_name == "dbm_gnu" and not have_gdbm:
             pytest.skip("requires gdbm")
         if item_name == "dbm_ndbm":


### PR DESCRIPTION
Not sure if this is the right solution, happy to conditionalize the MovedModule thing instead.
     