### PR TITLE
Python 3.14 removed the URLopener and FancyURLopener  classes from urllib.request

### DIFF
--- a/six.py
+++ b/six.py
@@ -435,12 +435,17 @@ _urllib_request_moved_attributes = [
     MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
     MovedAttribute("urlretrieve", "urllib", "urllib.request"),
     MovedAttribute("urlcleanup", "urllib", "urllib.request"),
-    MovedAttribute("URLopener", "urllib", "urllib.request"),
-    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
     MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
     MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
     MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
 ]
+if sys.version_info[:2] < (3, 14):
+    _urllib_request_moved_attributes.extend(
+        [
+            MovedAttribute("URLopener", "urllib", "urllib.request"),
+            MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+        ]
+    )
 for attr in _urllib_request_moved_attributes:
     setattr(Module_six_moves_urllib_request, attr.name, attr)
 del attr


### PR DESCRIPTION
https://github.com/python/cpython/issues/84850

> Remove URLopener and FancyURLopener classes from urllib.request.
> They had previously raised DeprecationWarning since Python 3.3.

The test failures were:

    __________________ test_move_items_urllib_request[URLopener] ___________________

    item_name = 'URLopener'

        @pytest.mark.parametrize("item_name",
                                  [item.name for item in six._urllib_request_moved_attributes])
        def test_move_items_urllib_request(item_name):
            """Ensure that everything loads correctly."""
            assert item_name in dir(six.moves.urllib.request)
    >       getattr(six.moves.urllib.request, item_name)
    E       AttributeError: module 'six.moves.urllib.request' has no attribute 'URLopener'

    test_six.py:170: AttributeError
    ________________ test_move_items_urllib_request[FancyURLopener] ________________

    item_name = 'FancyURLopener'

        @pytest.mark.parametrize("item_name",
                                  [item.name for item in six._urllib_request_moved_attributes])
        def test_move_items_urllib_request(item_name):
            """Ensure that everything loads correctly."""
            assert item_name in dir(six.moves.urllib.request)
    >       getattr(six.moves.urllib.request, item_name)
    E       AttributeError: module 'six.moves.urllib.request' has no attribute 'FancyURLopener'

    test_six.py:170: AttributeError